### PR TITLE
fix layoutbox tooltip for multiscreen setups

### DIFF
--- a/widget/layoutbox.lua
+++ b/widget/layoutbox.lua
@@ -141,6 +141,12 @@ function layoutbox.new(args, style)
 	--------------------------------------------------------------------------------
 	tag.connect_signal("property::selected", update)
 	tag.connect_signal("property::layout", update)
+	w:connect_signal("mouse::enter",
+		function()
+			local layout = layout.getname(layout.get(s))
+			layoutbox:update_tooltip(layout)
+		end
+	)
 	w:connect_signal("mouse::leave",
 		function()
 			if layoutbox.menu.hidetimer and layoutbox.menu.wibox.visible then


### PR DESCRIPTION
### Preface

Imagine the following situation:

- there are two screens which use separate layouts on their current tag
  - screen 1: Fair Tile
  - screen 2: Grid
- both screens have an individual panel containing a layoutbox and separate tags

### Issue

When hovering the mouse over any of the `layoutbox` widgets, the tooltip always displays the 2nd screen's layout name ("Grid" in above case).

### Reason

- the [`layoutbox:update()` function](https://github.com/worron/redflat/blob/b81c0555edc44abf6503cf2db00447f7f10a3346/widget/layoutbox.lua#L130) is called on both `layoutbox`es every time a tag changes on any of the screens
- the second screen's `update()` call is always the last one
- since both `layoutbox`es essentially share the same `tooltip` instance (as well as the same `menu` instance), the `tooltip` instance is always updated with the second screen's layout name with the last `update()` call
- when moving the mouse above the `layoutbox` and the `tooltip` is displayed, the text is not updated and retains the value from the last `update()` call, which is always the second screen's


### Fix

This pull requests simply adds a new `mouse::enter` signal binding to the `layoutbox` that refreshes the tooltip:

    w:connect_signal("mouse::enter",
        function()
            local layout = layout.getname(layout.get(s))
            layoutbox:update_tooltip(layout)
        end
    )

Feel free to edit or reject if there's a better way to do this.