### PR TITLE
Fix multiscreen behavior for tasklist's tagmenu

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -365,6 +365,26 @@ function menu:set_keys(keys, layout)
 	end
 end
 
+-- Clears all items from the menu
+--------------------------------------------------------------------------------
+function menu:clear()
+	self.add_size = 0
+	self.layout:remove_widgets()
+	self.layout:reset()
+	for k, _ in pairs(self.items) do self.items[k]=nil end
+	self.wibox.height = 1
+end
+
+-- Clears and then refills the menu with the given items
+--------------------------------------------------------------------------------
+function menu:replace_items(items, style)
+	self:clear()
+	for _, item in ipairs(items) do
+		self:add(item)
+	end
+	self.wibox.height = self.add_size > 0 and self.add_size or 1
+end
+
 -- Add a new menu entry.
 -- args.new (Default: redflat.menu.entry) The menu entry constructor.
 -- args.theme (Optional) The menu entry theme.
@@ -546,21 +566,23 @@ function menu.new(args, parent)
 	-- Initialize menu object
 	------------------------------------------------------------
 	local _menu = {
-		item_enter   = menu.item_enter,
-		item_leave   = menu.item_leave,
-		get_root     = menu.get_root,
-		delete       = menu.delete,
-		toggle       = menu.toggle,
-		hide         = menu.hide,
-		show         = menu.show,
-		exec         = menu.exec,
-		add          = menu.add,
-		items        = {},
-		keys         = {},
-		parent       = parent,
-		layout       = wibox.layout.fixed.vertical(),
-		add_size     = 0,
-		theme        = redutil.table.merge(parent and parent.theme or default_theme(), args.theme or {})
+		item_enter    = menu.item_enter,
+		item_leave    = menu.item_leave,
+		get_root      = menu.get_root,
+		delete        = menu.delete,
+		toggle        = menu.toggle,
+		hide          = menu.hide,
+		show          = menu.show,
+		exec          = menu.exec,
+		add           = menu.add,
+		clear         = menu.clear,
+		replace_items = menu.replace_items,
+		items         = {},
+		keys          = {},
+		parent        = parent,
+		layout        = wibox.layout.fixed.vertical(),
+		add_size      = 0,
+		theme         = redutil.table.merge(parent and parent.theme or default_theme(), args.theme or {})
 	}
 
 	-- Create items

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -41,7 +41,8 @@ local last = {
 	client      = nil,
 	group       = nil,
 	client_list = nil,
-	screen      = mouse.screen
+	screen      = mouse.screen,
+	tag_screen  = mouse.screen
 }
 
 -- Generate default theme vars
@@ -135,9 +136,30 @@ local function tagmenu_items(action, style)
 	return items
 end
 
+-- Function to rebuild the submenu entries according to current screen's tags
+--------------------------------------------------------------------------------
+local function tagmenu_rebuild(menu, submenu_index, style)
+       for _, index in ipairs(submenu_index) do
+               local new_items
+               if index == 1 then
+                   new_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
+               else
+                   new_items = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
+               end
+               menu.items[index].child:replace_items(new_items, style)
+       end
+end
+
+
 -- Function to update tag submenu icons
 --------------------------------------------------------------------------------
 local function tagmenu_update(c, menu, submenu_index, style)
+	-- if the screen has changed (and thus the tags) since the last time the
+	-- tagmenu was built, rebuild it first
+	if last.tag_screen ~= mouse.screen then
+		tagmenu_rebuild(menu, submenu_index, style)
+		last.tag_screen = mouse.screen
+	end
 	for k, t in ipairs(last.screen.tags) do
 		if not awful.tag.getproperty(t, "hide") then
 


### PR DESCRIPTION
The current implementation does not support a different `tag` constellation or `tag` order between multiple screens. This fix will replace (and thus update) each `tagmenu`'s items whenever the active screen has changed since the last `tagmenu_update()` call.

Please review the code - if you notice any possible improvement or issue, feel free to discuss and/or edit accordingly.