### PR TITLE
initalize property icons with already active properties correctly

### DIFF
--- a/titlebar.lua
+++ b/titlebar.lua
@@ -302,6 +302,7 @@ end
 ------------------------------------------------------------
 function titlebar.icon.property(c, prop, style)
 	local w = titlebar.icon.base(c, style)
+	w:set_active(c[prop])
 	c:connect_signal("property::" .. prop, function() w:set_active(c[prop]) end)
 	return w
 end


### PR DESCRIPTION
When a client is spawned that already has a property active from the start (e.g. when setting `sticky = true` in the corresponding `awful.rules`) the `redflat.titlebar.icon.property` is not initialized as being `active`. This seems due to the property being set before the `property::` signal of the icon is connected, thus missing the property activation.

I've added a simple `set_active()` call in the property icon's constructor. Since it takes the current property state as an argument there should be no danger of false positives.