### PR TITLE
apply highlight color to icons in menus

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -274,6 +274,8 @@ function menu:item_enter(num, opts)
 
 	item._background:set_fg(item.theme.color.highlight)
 	item._background:set_bg(item.theme.color.main)
+	if item.icon then item.icon:set_color(item.theme.color.highlight) end
+	if item.right_icon then item.right_icon:set_color(item.theme.color.highlight) end
 	self.sel = num
 
 	if self.theme.auto_expand and opts.hover and self.items[num].child then
@@ -289,6 +291,15 @@ function menu:item_leave(num)
 	if item then
 		item._background:set_fg(item.theme.color.text)
 		item._background:set_bg(item.theme.color.wibox)
+		if item.icon then item.icon:set_color(item.theme.color.left_icon) end
+		if item.right_icon then
+			if item.child then
+				-- if there's a child menu, this is a submenu icon
+				item.right_icon:set_color(item.theme.color.submenu_icon)
+			else
+				item.right_icon:set_color(item.theme.color.right_icon)
+			end
+		end
 		if item.child then item.child:hide() end
 	end
 end


### PR DESCRIPTION
## Issue

Currently the `theme.color.highlight` color when selecting/hovering a menu entry is only applied to text. The icons attached to the menu entries keep their color. This is bad for color schemes that rely on the highlight color to produce sufficient contrast to the `theme.color.main` accent:

![old](https://user-images.githubusercontent.com/1408105/32192857-b7befd8e-bdb5-11e7-86cf-f04c597f309f.png)

## Proposed Fix

The fix in this PR will tint icons in the highlight color as well:

![new](https://user-images.githubusercontent.com/1408105/32192861-bc2b4896-bdb5-11e7-8fb5-38939e3140cc.png)
