### PR TITLE
Fix mouse hover on initial menu selection not auto-expanding child menu

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -266,6 +266,10 @@ function menu:item_enter(num, opts)
 	local opts = opts or {}
 	local item = self.items[num]
 
+	if item and self.theme.auto_expand and opts.hover and item.child then
+		self.items[num].child:show()
+	end
+
 	if num == nil or self.sel == num or not item then
 		return
 	elseif self.sel then
@@ -280,10 +284,6 @@ function menu:item_enter(num, opts)
 		item.right_icon:set_color(item.theme.color.highlight)
 	end
 	self.sel = num
-
-	if self.theme.auto_expand and opts.hover and self.items[num].child then
-		self.items[num].child:show()
-	end
 end
 
 -- Unselect item


### PR DESCRIPTION
## Issue

When the menu entry that is initially highlighted is hovered with the mouse directly, it does not expand its child menu even if `theme.auto_expand` is set:

![old](https://user-images.githubusercontent.com/1408105/32225527-cb50f736-be45-11e7-98a8-c1ec29079654.gif)

I'm aware this is usually not a problem since you'd normally move the cursor from the bottom, hovering other elements first and not traveling around the menu like I did in the screencap here (which I only did for illustration purposes). However, when you have a menu popping up downwards it does become more of an issue, as it does for a new widget I'm currently working on. So I thought it would be nice to have this fixed in general.

## Proposed Fix

The commit will pull the `child:show()` call before the `self.sel == num` check so that even if the item is already preselected, mouse hovering will still trigger the child menu expansion if `theme.auto_expand` is set:

![new](https://user-images.githubusercontent.com/1408105/32225519-c59f3cee-be45-11e7-83db-f47240e48ddc.gif)
