### PR TITLE
Fix cover image handling for player widget

### DIFF
--- a/float/player.lua
+++ b/float/player.lua
@@ -40,6 +40,11 @@ local dbus_set = dbus_mpris
 local dbus_action = dbus_mpris
                     .. "org.mpris.MediaPlayer2.Player."
 
+-- Helper function to decode URI string format
+-----------------------------------------------------------------------------------------------------------------------
+local function decodeURI(s)
+    return string.gsub(s, '%%(%x%x)', function(hex) return string.char(tonumber(hex, 15)) end)
+end
 
 -- Generate default theme vars
 -----------------------------------------------------------------------------------------------------------------------
@@ -369,7 +374,10 @@ function player:listen()
 				if data.Metadata["mpris:artUrl"] then
 					local image = string.match(data.Metadata["mpris:artUrl"], "file://(.+)")
 					self.box.image:set_color(nil)
-					self.box.image:set_image(image)
+					self.box.image:set_image(decodeURI(image))
+				else
+					-- reset to generic icon if no cover available
+					self.box.image:set_image(self.style.icon.cover)
 				end
 
 				-- track length

--- a/float/player.lua
+++ b/float/player.lua
@@ -43,7 +43,7 @@ local dbus_action = dbus_mpris
 -- Helper function to decode URI string format
 -----------------------------------------------------------------------------------------------------------------------
 local function decodeURI(s)
-    return string.gsub(s, '%%(%x%x)', function(hex) return string.char(tonumber(hex, 15)) end)
+    return string.gsub(s, '%%(%x%x)', function(hex) return string.char(tonumber(hex, 16)) end)
 end
 
 -- Generate default theme vars


### PR DESCRIPTION
## Issue

I've faced a bunch of rendering issues with the player widget recently, which seem to boil down to the cover image handling failing for my player (which is Audacious). The symptoms range from completely empty player widget, missing controls/text on the widget to wrong values.

Audacious uses URI encode when it's pointing to a cover image files whose path contains spaces, this is not supported by the player widget:

    E: Failed to load '/home/mahe/Musik/Album%20Name%20With%20Spaces/cover.png': Failed to open file '/home/mahe/Musik/Album%20Name%20With%20Spaces/cover.png': No such file or directory

This leads to redrawing errors on the widget:

    E: Error during a protected call: /home/mahe/.config/awesome/redflat/gauge/svgbox.lua:171: bad argument #2 to 'set_source_pixbuf' (GdkPixbuf.Pixbuf expected, got nil)
    stack traceback:
        [C]: in function 'set_source_pixbuf'
        /home/mahe/.config/awesome/redflat/gauge/svgbox.lua:171: in function </home/mahe/.config/awesome/redflat/gauge/svgbox.lua:159>
        (tail call): ?
        [C]: in function 'xpcall'
        /usr/share/awesome/lib/gears/protected_call.lua:30: in function </usr/share/awesome/lib/gears/protected_call.lua:28>
        (tail call): ?
        /usr/share/awesome/lib/wibox/hierarchy.lua:323: in function 'call'
        /usr/share/awesome/lib/wibox/hierarchy.lua:338: in function 'draw'
        /usr/share/awesome/lib/wibox/hierarchy.lua:345: in function 'draw'
        /usr/share/awesome/lib/wibox/hierarchy.lua:345: in function 'draw'
        /usr/share/awesome/lib/wibox/drawable.lua:160: in function 'do_redraw'
        /usr/share/awesome/lib/wibox/drawable.lua:390: in function </usr/share/awesome/lib/wibox/drawable.lua:388>
        (tail call): ?
        [C]: in function 'xpcall'
        /usr/share/awesome/lib/gears/protected_call.lua:30: in function </usr/share/awesome/lib/gears/protected_call.lua:28>
        (tail call): ?
        /usr/share/awesome/lib/gears/timer.lua:226: in function </usr/share/awesome/lib/gears/timer.lua:224>

This somehow also affects other elements on the player widget including buttons, text etc. These elements start to disappear from the widget individually or the widget becomes entirely empty.

## Proposed Fix

I've added URI decode functionality to the `mpris:artUrl` handling, which enables the widget to correctly load any cover paths provided by the Audacious player. I also added a reset to `style.icon.cover` if no cover image is provided via mpris.