### PR TITLE
Small QoL fixes

### DIFF
--- a/float/appswitcher.lua
+++ b/float/appswitcher.lua
@@ -409,6 +409,7 @@ function appswitcher:show(args)
 
 	self.index = awful.util.table.hasitem(self.clients_list, client.focus) or 1
 	self.winmark(self.clients_list[self.index], true)
+	self.titlebox:set_markup(self.title_generator(self.clients_list[self.index]))
 	if not noaction then self:switch(args) end
 	self.widget:emit_signal("widget::updated")
 

--- a/float/keychain.lua
+++ b/float/keychain.lua
@@ -22,7 +22,7 @@ local redtip = require("redflat.float.hotkeys")
 local keychain = {}
 local tip_cache = {}
 
-local label_pattern = { Mod4 = "M", Control = "C", Shift = "S" }
+local label_pattern = { Mod1 = "A", Mod4 = "M", Control = "C", Shift = "S" }
 
 -- key bindings
 keychain.service = { close = { "Escape" }, help = { "F1" }, stepback = { "BackSpace" } }

--- a/service/navigator.lua
+++ b/service/navigator.lua
@@ -252,7 +252,7 @@ function navigator:run()
 	local l = awful.layout.get(client.focus.screen)
 	local handler = l.key_handler or redflat.layout.common.handler[l]
 	if not handler then
-		rednotify:show(redutil.table.merge({ text = "Layoout doesn't supported" }, self.style.notify))
+		rednotify:show(redutil.table.merge({ text = "Layout not supported" }, self.style.notify))
 		return
 	end
 


### PR DESCRIPTION
A small collection of minor fixes:

1. when calling `appswitcher:show()` with `noaction = true` the caption of the focused client was still set to "`TEXT`" until the first switch was done
    - this is fixed by setting the titlebox text in `show()`
2. the notification of the `navigator` for unsupported layouts contained spelling mistakes
3. using the Alt (Mod1) key as the global `env.mod` key caused errors in `keychain` rendering the whole UI unusable at times
    - I added support for Mod1 to the `keychain` module