### PR TITLE
New float widget: clientmenu

### DIFF
--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -32,35 +32,35 @@ local svgbox = require("redflat.gauge.svgbox")
 local clientmenu = { mt = {}, }
 
 local last = {
-    client      = nil,
-    screen      = mouse.screen,
-    tag_screen  = mouse.screen
+	client      = nil,
+	screen      = mouse.screen,
+	tag_screen  = mouse.screen
 }
 
 -- Generate default theme vars
 -----------------------------------------------------------------------------------------------------------------------
 local function default_style()
-    local style = {
-        icon           = { unknown = redutil.base.placeholder(),
-                           minimize = redutil.base.placeholder(),
-                           close = redutil.base.placeholder() },
-        micon          = { blank = redutil.base.placeholder({ txt = " " }),
-                           check = redutil.base.placeholder({ txt = "+" }) },
-        layout_icon    = { unknown = redutil.base.placeholder() },
-        actionline     = { height = 28 },
-        stateline      = { height = 35 },
-        state_iconsize = { width = 20, height = 20 },
-        sep_margin     = { 3, 3, 5, 5 },
-        tagmenu        = { icon_margin = { 2, 2, 2, 2 } },
-        color          = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040" },
-    }
-    style.menu = {
-        ricon_margin = { 2, 2, 2, 2 },
-        hide_timeout = 1,
-        nohide       = true
-    }
+	local style = {
+		icon           = { unknown = redutil.base.placeholder(),
+		                   minimize = redutil.base.placeholder(),
+		                   close = redutil.base.placeholder() },
+		micon          = { blank = redutil.base.placeholder({ txt = " " }),
+		                   check = redutil.base.placeholder({ txt = "+" }) },
+		layout_icon    = { unknown = redutil.base.placeholder() },
+		actionline     = { height = 28 },
+		stateline      = { height = 35 },
+		state_iconsize = { width = 20, height = 20 },
+		sep_margin     = { 3, 3, 5, 5 },
+		tagmenu        = { icon_margin = { 2, 2, 2, 2 } },
+		color          = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040" },
+	}
+	style.menu = {
+		ricon_margin = { 2, 2, 2, 2 },
+		hide_timeout = 1,
+		nohide       = true
+	}
 
-    return redutil.table.merge(style, redutil.table.check(beautiful, "widget.clientmenu") or {})
+	return redutil.table.merge(style, redutil.table.check(beautiful, "widget.clientmenu") or {})
 end
 
 -- Support functions
@@ -69,295 +69,295 @@ end
 -- Function to build item list for submenu
 --------------------------------------------------------------------------------
 local function tagmenu_items(action, style)
-    local items = {}
-    for _, t in ipairs(last.screen.tags) do
-        if not awful.tag.getproperty(t, "hide") then
-            table.insert(
-                items,
-                { t.name, function() action(t) end, style.micon.blank, style.micon.blank }
-            )
-        end
-    end
-    return items
+	local items = {}
+	for _, t in ipairs(last.screen.tags) do
+		if not awful.tag.getproperty(t, "hide") then
+			table.insert(
+				items,
+				{ t.name, function() action(t) end, style.micon.blank, style.micon.blank }
+			)
+		end
+	end
+	return items
 end
 
 -- Function to rebuild the submenu entries according to current screen's tags
 --------------------------------------------------------------------------------
 local function tagmenu_rebuild(menu, submenu_index, style)
-    for _, index in ipairs(submenu_index) do
-            local new_items
-            if index == 1 then
-                new_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
-            else
-                new_items = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
-            end
-            menu.items[index].child:replace_items(new_items)
-    end
+	for _, index in ipairs(submenu_index) do
+			local new_items
+			if index == 1 then
+				new_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
+			else
+				new_items = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
+			end
+			menu.items[index].child:replace_items(new_items)
+	end
 end
 
 -- Function to update tag submenu icons
 --------------------------------------------------------------------------------
 local function tagmenu_update(c, menu, submenu_index, style)
-    -- if the screen has changed (and thus the tags) since the last time the
-    -- tagmenu was built, rebuild it first
-    if last.tag_screen ~= mouse.screen then
-        tagmenu_rebuild(menu, submenu_index, style)
-        last.tag_screen = mouse.screen
-    end
-    for k, t in ipairs(last.screen.tags) do
-        if not awful.tag.getproperty(t, "hide") then
+	-- if the screen has changed (and thus the tags) since the last time the
+	-- tagmenu was built, rebuild it first
+	if last.tag_screen ~= mouse.screen then
+		tagmenu_rebuild(menu, submenu_index, style)
+		last.tag_screen = mouse.screen
+	end
+	for k, t in ipairs(last.screen.tags) do
+		if not awful.tag.getproperty(t, "hide") then
 
-            -- set layout icon for every tag
-            local l = awful.layout.getname(awful.tag.getproperty(t, "layout"))
+			-- set layout icon for every tag
+			local l = awful.layout.getname(awful.tag.getproperty(t, "layout"))
 
-            for _, index in ipairs(submenu_index) do
-                if menu.items[index].child.items[k].icon then
-                    menu.items[index].child.items[k].icon:set_image(style.layout_icon[l] or style.layout_icon.unknown)
-                end
-            end
+			for _, index in ipairs(submenu_index) do
+				if menu.items[index].child.items[k].icon then
+					menu.items[index].child.items[k].icon:set_image(style.layout_icon[l] or style.layout_icon.unknown)
+				end
+			end
 
-            -- set "checked" icon if tag active for given client
-            -- otherwise set empty icon
-            if c then
-                local client_tags = c:tags()
-                local check_icon = awful.util.table.hasitem(client_tags, t) and style.micon.check
-                                   or style.micon.blank
+			-- set "checked" icon if tag active for given client
+			-- otherwise set empty icon
+			if c then
+				local client_tags = c:tags()
+				local check_icon = awful.util.table.hasitem(client_tags, t) and style.micon.check
+				                   or style.micon.blank
 
-                for _, index in ipairs(submenu_index) do
-                    if menu.items[index].child.items[k].right_icon then
-                        menu.items[index].child.items[k].right_icon:set_image(check_icon)
-                    end
-                end
-            end
-        end
-    end
+				for _, index in ipairs(submenu_index) do
+					if menu.items[index].child.items[k].right_icon then
+						menu.items[index].child.items[k].right_icon:set_image(check_icon)
+					end
+				end
+			end
+		end
+	end
 end
 
 -- Function to construct menu line with state icons
 --------------------------------------------------------------------------------
 local function state_line_construct(state_icons, setup_layout, style)
-    local stateboxes = {}
+	local stateboxes = {}
 
-    for i, v in ipairs(state_icons) do
-        -- create widget
-        stateboxes[i] = svgbox(v.icon)
-        stateboxes[i]:set_forced_width(style.state_iconsize.width)
-        stateboxes[i]:set_forced_height(style.state_iconsize.height)
+	for i, v in ipairs(state_icons) do
+		-- create widget
+		stateboxes[i] = svgbox(v.icon)
+		stateboxes[i]:set_forced_width(style.state_iconsize.width)
+		stateboxes[i]:set_forced_height(style.state_iconsize.height)
 
-        -- set widget in line
-        local l = wibox.layout.align.horizontal()
-        l:set_expand("outside")
-        l:set_second(stateboxes[i])
-        setup_layout:add(l)
+		-- set widget in line
+		local l = wibox.layout.align.horizontal()
+		l:set_expand("outside")
+		l:set_second(stateboxes[i])
+		setup_layout:add(l)
 
-        -- set mouse action
-        stateboxes[i]:buttons(awful.util.table.join(awful.button({}, 1,
-            function()
-                v.action()
-                stateboxes[i]:set_color(v.indicator(last.client) and style.color.main or style.color.gray)
-            end
-        )))
-    end
+		-- set mouse action
+		stateboxes[i]:buttons(awful.util.table.join(awful.button({}, 1,
+			function()
+				v.action()
+				stateboxes[i]:set_color(v.indicator(last.client) and style.color.main or style.color.gray)
+			end
+		)))
+	end
 
-    return stateboxes
+	return stateboxes
 end
 
 -- Function to construct menu line with action icons (minimize, close)
 --------------------------------------------------------------------------------
 local function action_line_construct(setup_layout, style)
-    local sep = separator.vertical({ margin = style.sep_margin })
+	local sep = separator.vertical({ margin = style.sep_margin })
 
-    local function actionbox_construct(icon, action)
-        local iconbox = svgbox(icon, nil, style.color.text)
-        iconbox:set_forced_width(style.state_iconsize.width)
-        iconbox:set_forced_height(style.state_iconsize.height)
+	local function actionbox_construct(icon, action)
+		local iconbox = svgbox(icon, nil, style.color.text)
+		iconbox:set_forced_width(style.state_iconsize.width)
+		iconbox:set_forced_height(style.state_iconsize.height)
 
-        -- center iconbox both vertically and horizontally
-        local vert_wrapper = wibox.layout.align.vertical()
-        vert_wrapper:set_second(iconbox)
-        vert_wrapper:set_expand("outside")
-        local horiz_wrapper = wibox.layout.align.horizontal()
-        horiz_wrapper:set_second(vert_wrapper)
-        horiz_wrapper:set_expand("outside")
+		-- center iconbox both vertically and horizontally
+		local vert_wrapper = wibox.layout.align.vertical()
+		vert_wrapper:set_second(iconbox)
+		vert_wrapper:set_expand("outside")
+		local horiz_wrapper = wibox.layout.align.horizontal()
+		horiz_wrapper:set_second(vert_wrapper)
+		horiz_wrapper:set_expand("outside")
 
-        -- wrap into a background container to allow bg color change of area
-        local actionbox = wibox.container.background(horiz_wrapper)
+		-- wrap into a background container to allow bg color change of area
+		local actionbox = wibox.container.background(horiz_wrapper)
 
-        -- set mouse action
-        actionbox:buttons(awful.util.table.join(awful.button({}, 1,
-            function()
-                action()
-                clientmenu.menu:hide()  -- close menu on action
-            end
-        )))
-        actionbox:connect_signal("mouse::enter",
-            function()
-                iconbox:set_color(style.color.highlight)
-                actionbox.bg = style.color.main
-            end
-        )
-        actionbox:connect_signal("mouse::leave",
-            function()
-                iconbox:set_color(style.color.text)
-                actionbox.bg = nil
-            end
-        )
-        return actionbox
-    end
+		-- set mouse action
+		actionbox:buttons(awful.util.table.join(awful.button({}, 1,
+			function()
+				action()
+				clientmenu.menu:hide()  -- close menu on action
+			end
+		)))
+		actionbox:connect_signal("mouse::enter",
+			function()
+				iconbox:set_color(style.color.highlight)
+				actionbox.bg = style.color.main
+			end
+		)
+		actionbox:connect_signal("mouse::leave",
+			function()
+				iconbox:set_color(style.color.text)
+				actionbox.bg = nil
+			end
+		)
+		return actionbox
+	end
 
-    -- minimize button
-    local minimize_box = actionbox_construct(
-        style.icon.minimize,
-        function()
-            last.client.minimized = not last.client.minimized
-        end
-    )
-    setup_layout:set_first(minimize_box)
+	-- minimize button
+	local minimize_box = actionbox_construct(
+		style.icon.minimize,
+		function()
+			last.client.minimized = not last.client.minimized
+		end
+	)
+	setup_layout:set_first(minimize_box)
 
-    -- separator
-    local sep_wrapper = wibox.layout.align.horizontal()
-    sep_wrapper:set_second(sep)
-    sep_wrapper:set_expand("outside")
-    setup_layout:set_second(sep_wrapper)
+	-- separator
+	local sep_wrapper = wibox.layout.align.horizontal()
+	sep_wrapper:set_second(sep)
+	sep_wrapper:set_expand("outside")
+	setup_layout:set_second(sep_wrapper)
 
-    -- close button
-    local close_box = actionbox_construct(
-        style.icon.close,
-        function()
-            last.client:kill()
-        end
-    )
-    setup_layout:set_third(close_box)
+	-- close button
+	local close_box = actionbox_construct(
+		style.icon.close,
+		function()
+			last.client:kill()
+		end
+	)
+	setup_layout:set_third(close_box)
 end
 
 -- Calculate menu position
 --------------------------------------------------------------------------------
 local function coords_calc(menu)
-    local coords = {}
+	local coords = {}
 
-    coords = mouse.coords()
-    coords.x = coords.x - menu.wibox.width / 2 - menu.wibox.border_width
+	coords = mouse.coords()
+	coords.x = coords.x - menu.wibox.width / 2 - menu.wibox.border_width
 
-    return coords
+	return coords
 end
 
 -- Initialize window menu widget
 -----------------------------------------------------------------------------------------------------------------------
 function clientmenu:init(style)
-    local style = redutil.table.merge(default_style(), style or {})
+	local style = redutil.table.merge(default_style(), style or {})
 
-    -- Create array of state icons
-    -- associate every icon with action and state indicator
-    --------------------------------------------------------------------------------
-    local function icon_table_generator_prop(property)
-        return {
-            icon      = style.icon[property] or style.icon.unknown,
-            action    = function() last.client[property] = not last.client[property] end,
-            indicator = function(c) return c[property] end
-        }
-    end
+	-- Create array of state icons
+	-- associate every icon with action and state indicator
+	--------------------------------------------------------------------------------
+	local function icon_table_generator_prop(property)
+		return {
+			icon      = style.icon[property] or style.icon.unknown,
+			action    = function() last.client[property] = not last.client[property] end,
+			indicator = function(c) return c[property] end
+		}
+	end
 
-    local state_icons = {
-        icon_table_generator_prop("floating"),
-        icon_table_generator_prop("sticky"),
-        icon_table_generator_prop("ontop"),
-        icon_table_generator_prop("below"),
-        icon_table_generator_prop("maximized"),
-    }
+	local state_icons = {
+		icon_table_generator_prop("floating"),
+		icon_table_generator_prop("sticky"),
+		icon_table_generator_prop("ontop"),
+		icon_table_generator_prop("below"),
+		icon_table_generator_prop("maximized"),
+	}
 
-    -- Construct menu
-    --------------------------------------------------------------------------------
+	-- Construct menu
+	--------------------------------------------------------------------------------
 
-    -- Window action line construction
-    ------------------------------------------------------------
+	-- Window action line construction
+	------------------------------------------------------------
 
-    local actionline_horizontal = wibox.layout.align.horizontal()
-    actionline_horizontal:set_expand("outside")
-    local actionline_vertical = wibox.layout.align.vertical()
-    actionline_vertical:set_second(actionline_horizontal)
-    actionline_vertical:set_expand("outside")
-    local actionline = wibox.container.constraint(actionline_vertical, "exact", nil, style.actionline.height)
-    action_line_construct(actionline_horizontal, style)
+	local actionline_horizontal = wibox.layout.align.horizontal()
+	actionline_horizontal:set_expand("outside")
+	local actionline_vertical = wibox.layout.align.vertical()
+	actionline_vertical:set_second(actionline_horizontal)
+	actionline_vertical:set_expand("outside")
+	local actionline = wibox.container.constraint(actionline_vertical, "exact", nil, style.actionline.height)
+	action_line_construct(actionline_horizontal, style)
 
-    -- Window state line construction
-    ------------------------------------------------------------
+	-- Window state line construction
+	------------------------------------------------------------
 
-    -- layouts
-    local stateline_horizontal = wibox.layout.flex.horizontal()
-    local stateline_vertical = wibox.layout.align.vertical()
-    stateline_vertical:set_second(stateline_horizontal)
-    stateline_vertical:set_expand("outside")
-    local stateline = wibox.container.constraint(stateline_vertical, "exact", nil, style.stateline.height)
+	-- layouts
+	local stateline_horizontal = wibox.layout.flex.horizontal()
+	local stateline_vertical = wibox.layout.align.vertical()
+	stateline_vertical:set_second(stateline_horizontal)
+	stateline_vertical:set_expand("outside")
+	local stateline = wibox.container.constraint(stateline_vertical, "exact", nil, style.stateline.height)
 
-    -- set all state icons in line
-    local stateboxes = state_line_construct(state_icons, stateline_horizontal, style)
+	-- set all state icons in line
+	local stateboxes = state_line_construct(state_icons, stateline_horizontal, style)
 
-    -- update function for state icons
-    local function stateboxes_update(c, state_icons, stateboxes)
-        for i, v in ipairs(state_icons) do
-            stateboxes[i]:set_color(v.indicator(c) and style.color.main or style.color.gray)
-        end
-    end
+	-- update function for state icons
+	local function stateboxes_update(c, state_icons, stateboxes)
+		for i, v in ipairs(state_icons) do
+			stateboxes[i]:set_color(v.indicator(c) and style.color.main or style.color.gray)
+		end
+	end
 
-    -- Separators config
-    ------------------------------------------------------------
-    local menusep = { widget = separator.horizontal({ margin = style.sep_margin }) }
+	-- Separators config
+	------------------------------------------------------------
+	local menusep = { widget = separator.horizontal({ margin = style.sep_margin }) }
 
-    -- Construct tag submenus ("move" and "add")
-    ------------------------------------------------------------
-    local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
-    local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t)  end, style)
+	-- Construct tag submenus ("move" and "add")
+	------------------------------------------------------------
+	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
+	local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t)  end, style)
 
-    -- Create menu
-    ------------------------------------------------------------
-    self.menu = redmenu({
-        hide_timeout = 1,
-        theme = style.menu,
-        items = {
-            { widget = actionline },
-            menusep,
-            { "Move to tag", { items = movemenu_items, theme = style.tagmenu } },
-            { "Add to tag",  { items = addmenu_items,  theme = style.tagmenu } },
-            menusep,
-            { widget = stateline }
-        }
-    })
+	-- Create menu
+	------------------------------------------------------------
+	self.menu = redmenu({
+		hide_timeout = 1,
+		theme = style.menu,
+		items = {
+			{ widget = actionline },
+			menusep,
+			{ "Move to tag", { items = movemenu_items, theme = style.tagmenu } },
+			{ "Add to tag",  { items = addmenu_items,  theme = style.tagmenu } },
+			menusep,
+			{ widget = stateline }
+		}
+	})
 
-    -- Widget update functions
-    --------------------------------------------------------------------------------
-    function self:update(c)
-        if self.menu.wibox.visible then
-            stateboxes_update(c, state_icons, stateboxes)
-            tagmenu_update(c, self.menu, { 1, 2 }, style)
-        end
-    end
+	-- Widget update functions
+	--------------------------------------------------------------------------------
+	function self:update(c)
+		if self.menu.wibox.visible then
+			stateboxes_update(c, state_icons, stateboxes)
+			tagmenu_update(c, self.menu, { 1, 2 }, style)
+		end
+	end
 
-    -- Signals setup
-    --------------------------------------------------------------------------------
-    local client_signals = {
-        "property::ontop", "property::floating", "property::below", "property::maximized",
-        "tagged", "untagged"  -- refresh tagmenu when client's tags change
-    }
-    for _, sg in ipairs(client_signals) do
-        client.connect_signal(sg, function() self:update(last.client) end)
-    end
+	-- Signals setup
+	--------------------------------------------------------------------------------
+	local client_signals = {
+		"property::ontop", "property::floating", "property::below", "property::maximized",
+		"tagged", "untagged"  -- refresh tagmenu when client's tags change
+	}
+	for _, sg in ipairs(client_signals) do
+		client.connect_signal(sg, function() self:update(last.client) end)
+	end
 end
 
 -- Show window menu widget
 -----------------------------------------------------------------------------------------------------------------------
 function clientmenu:show(c)
 
-    -- toggle menu
-    if self.menu.wibox.visible and c == last.client and mouse.screen == last.screen  then
-        self.menu:hide()
-    else
-        last.client = c
-        last.screen = mouse.screen
-        self.menu:show({ coords = coords_calc(self.menu) })
+	-- toggle menu
+	if self.menu.wibox.visible and c == last.client and mouse.screen == last.screen  then
+		self.menu:hide()
+	else
+		last.client = c
+		last.screen = mouse.screen
+		self.menu:show({ coords = coords_calc(self.menu) })
 
-        if self.menu.hidetimer.started then self.menu.hidetimer:stop() end
-        self:update(c)
-    end
+		if self.menu.hidetimer.started then self.menu.hidetimer:stop() end
+		self:update(c)
+	end
 end
 
 return setmetatable(clientmenu, clientmenu.mt)

--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -1,0 +1,363 @@
+-----------------------------------------------------------------------------------------------------------------------
+--                                         RedFlat client menu widget                                               --
+-----------------------------------------------------------------------------------------------------------------------
+-- Custom float widget that provides client actions like the tasklist's window
+-- menu but may be used outside of the tasklist context on any client. Useful
+-- for titlebar click action or other custom client-related keybindings for
+-- faster access of client actions without traveling to the tasklist.
+-----------------------------------------------------------------------------------------------------------------------
+-- Authored by M4he
+-- Some code was taken from
+------ redflat.widget.tasklist
+-----------------------------------------------------------------------------------------------------------------------
+
+-- Grab environment
+-----------------------------------------------------------------------------------------------------------------------
+local setmetatable = setmetatable
+local ipairs = ipairs
+local table = table
+local beautiful = require("beautiful")
+local tag = require("awful.tag")
+local awful = require("awful")
+local wibox = require("wibox")
+local timer = require("gears.timer")
+
+local redutil = require("redflat.util")
+local separator = require("redflat.gauge.separator")
+local redmenu = require("redflat.menu")
+local svgbox = require("redflat.gauge.svgbox")
+
+-- Initialize tables and vars for module
+-----------------------------------------------------------------------------------------------------------------------
+local clientmenu = { mt = {}, }
+
+local last = {
+    client      = nil,
+    screen      = mouse.screen,
+    tag_screen  = mouse.screen
+}
+
+-- Generate default theme vars
+-----------------------------------------------------------------------------------------------------------------------
+local function default_style()
+    local style = {
+        icon           = { unknown = redutil.base.placeholder(),
+                           minimize = redutil.base.placeholder(),
+                           close = redutil.base.placeholder() },
+        micon          = { blank = redutil.base.placeholder({ txt = " " }),
+                           check = redutil.base.placeholder({ txt = "+" }) },
+        layout_icon    = { unknown = redutil.base.placeholder() },
+        actionline     = { height = 28 },
+        stateline      = { height = 35 },
+        state_iconsize = { width = 20, height = 20 },
+        sep_margin     = { 3, 3, 5, 5 },
+        tagmenu        = { icon_margin = { 2, 2, 2, 2 } },
+        color          = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040" },
+    }
+    style.menu = {
+        ricon_margin = { 2, 2, 2, 2 },
+        hide_timeout = 1,
+        nohide       = true
+    }
+
+    return redutil.table.merge(style, redutil.table.check(beautiful, "widget.clientmenu") or {})
+end
+
+-- Support functions
+-----------------------------------------------------------------------------------------------------------------------
+
+-- Function to build item list for submenu
+--------------------------------------------------------------------------------
+local function tagmenu_items(action, style)
+    local items = {}
+    for _, t in ipairs(last.screen.tags) do
+        if not awful.tag.getproperty(t, "hide") then
+            table.insert(
+                items,
+                { t.name, function() action(t) end, style.micon.blank, style.micon.blank }
+            )
+        end
+    end
+    return items
+end
+
+-- Function to rebuild the submenu entries according to current screen's tags
+--------------------------------------------------------------------------------
+local function tagmenu_rebuild(menu, submenu_index, style)
+    for _, index in ipairs(submenu_index) do
+            local new_items
+            if index == 1 then
+                new_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
+            else
+                new_items = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
+            end
+            menu.items[index].child:replace_items(new_items)
+    end
+end
+
+-- Function to update tag submenu icons
+--------------------------------------------------------------------------------
+local function tagmenu_update(c, menu, submenu_index, style)
+    -- if the screen has changed (and thus the tags) since the last time the
+    -- tagmenu was built, rebuild it first
+    if last.tag_screen ~= mouse.screen then
+        tagmenu_rebuild(menu, submenu_index, style)
+        last.tag_screen = mouse.screen
+    end
+    for k, t in ipairs(last.screen.tags) do
+        if not awful.tag.getproperty(t, "hide") then
+
+            -- set layout icon for every tag
+            local l = awful.layout.getname(awful.tag.getproperty(t, "layout"))
+
+            for _, index in ipairs(submenu_index) do
+                if menu.items[index].child.items[k].icon then
+                    menu.items[index].child.items[k].icon:set_image(style.layout_icon[l] or style.layout_icon.unknown)
+                end
+            end
+
+            -- set "checked" icon if tag active for given client
+            -- otherwise set empty icon
+            if c then
+                local client_tags = c:tags()
+                local check_icon = awful.util.table.hasitem(client_tags, t) and style.micon.check
+                                   or style.micon.blank
+
+                for _, index in ipairs(submenu_index) do
+                    if menu.items[index].child.items[k].right_icon then
+                        menu.items[index].child.items[k].right_icon:set_image(check_icon)
+                    end
+                end
+            end
+        end
+    end
+end
+
+-- Function to construct menu line with state icons
+--------------------------------------------------------------------------------
+local function state_line_construct(state_icons, setup_layout, style)
+    local stateboxes = {}
+
+    for i, v in ipairs(state_icons) do
+        -- create widget
+        stateboxes[i] = svgbox(v.icon)
+        stateboxes[i]:set_forced_width(style.state_iconsize.width)
+        stateboxes[i]:set_forced_height(style.state_iconsize.height)
+
+        -- set widget in line
+        local l = wibox.layout.align.horizontal()
+        l:set_expand("outside")
+        l:set_second(stateboxes[i])
+        setup_layout:add(l)
+
+        -- set mouse action
+        stateboxes[i]:buttons(awful.util.table.join(awful.button({}, 1,
+            function()
+                v.action()
+                stateboxes[i]:set_color(v.indicator(last.client) and style.color.main or style.color.gray)
+            end
+        )))
+    end
+
+    return stateboxes
+end
+
+-- Function to construct menu line with action icons (minimize, close)
+--------------------------------------------------------------------------------
+local function action_line_construct(setup_layout, style)
+    local sep = separator.vertical({ margin = style.sep_margin })
+
+    local function actionbox_construct(icon, action)
+        local iconbox = svgbox(icon, nil, style.color.text)
+        iconbox:set_forced_width(style.state_iconsize.width)
+        iconbox:set_forced_height(style.state_iconsize.height)
+
+        -- center iconbox both vertically and horizontally
+        local vert_wrapper = wibox.layout.align.vertical()
+        vert_wrapper:set_second(iconbox)
+        vert_wrapper:set_expand("outside")
+        local horiz_wrapper = wibox.layout.align.horizontal()
+        horiz_wrapper:set_second(vert_wrapper)
+        horiz_wrapper:set_expand("outside")
+
+        -- wrap into a background container to allow bg color change of area
+        local actionbox = wibox.container.background(horiz_wrapper)
+
+        -- set mouse action
+        actionbox:buttons(awful.util.table.join(awful.button({}, 1,
+            function()
+                action()
+                clientmenu.menu:hide()  -- close menu on action
+            end
+        )))
+        actionbox:connect_signal("mouse::enter",
+            function()
+                iconbox:set_color(style.color.highlight)
+                actionbox.bg = style.color.main
+            end
+        )
+        actionbox:connect_signal("mouse::leave",
+            function()
+                iconbox:set_color(style.color.text)
+                actionbox.bg = nil
+            end
+        )
+        return actionbox
+    end
+
+    -- minimize button
+    local minimize_box = actionbox_construct(
+        style.icon.minimize,
+        function()
+            last.client.minimized = not last.client.minimized
+        end
+    )
+    setup_layout:set_first(minimize_box)
+
+    -- separator
+    local sep_wrapper = wibox.layout.align.horizontal()
+    sep_wrapper:set_second(sep)
+    sep_wrapper:set_expand("outside")
+    setup_layout:set_second(sep_wrapper)
+
+    -- close button
+    local close_box = actionbox_construct(
+        style.icon.close,
+        function()
+            last.client:kill()
+        end
+    )
+    setup_layout:set_third(close_box)
+end
+
+-- Calculate menu position
+--------------------------------------------------------------------------------
+local function coords_calc(menu)
+    local coords = {}
+
+    coords = mouse.coords()
+    coords.x = coords.x - menu.wibox.width / 2 - menu.wibox.border_width
+
+    return coords
+end
+
+-- Initialize window menu widget
+-----------------------------------------------------------------------------------------------------------------------
+function clientmenu:init(style)
+    local style = redutil.table.merge(default_style(), style or {})
+
+    -- Create array of state icons
+    -- associate every icon with action and state indicator
+    --------------------------------------------------------------------------------
+    local function icon_table_generator_prop(property)
+        return {
+            icon      = style.icon[property] or style.icon.unknown,
+            action    = function() last.client[property] = not last.client[property] end,
+            indicator = function(c) return c[property] end
+        }
+    end
+
+    local state_icons = {
+        icon_table_generator_prop("floating"),
+        icon_table_generator_prop("sticky"),
+        icon_table_generator_prop("ontop"),
+        icon_table_generator_prop("below"),
+        icon_table_generator_prop("maximized"),
+    }
+
+    -- Construct menu
+    --------------------------------------------------------------------------------
+
+    -- Window action line construction
+    ------------------------------------------------------------
+
+    local actionline_horizontal = wibox.layout.align.horizontal()
+    actionline_horizontal:set_expand("outside")
+    local actionline_vertical = wibox.layout.align.vertical()
+    actionline_vertical:set_second(actionline_horizontal)
+    actionline_vertical:set_expand("outside")
+    local actionline = wibox.container.constraint(actionline_vertical, "exact", nil, style.actionline.height)
+    action_line_construct(actionline_horizontal, style)
+
+    -- Window state line construction
+    ------------------------------------------------------------
+
+    -- layouts
+    local stateline_horizontal = wibox.layout.flex.horizontal()
+    local stateline_vertical = wibox.layout.align.vertical()
+    stateline_vertical:set_second(stateline_horizontal)
+    stateline_vertical:set_expand("outside")
+    local stateline = wibox.container.constraint(stateline_vertical, "exact", nil, style.stateline.height)
+
+    -- set all state icons in line
+    local stateboxes = state_line_construct(state_icons, stateline_horizontal, style)
+
+    -- update function for state icons
+    local function stateboxes_update(c, state_icons, stateboxes)
+        for i, v in ipairs(state_icons) do
+            stateboxes[i]:set_color(v.indicator(c) and style.color.main or style.color.gray)
+        end
+    end
+
+    -- Separators config
+    ------------------------------------------------------------
+    local menusep = { widget = separator.horizontal({ margin = style.sep_margin }) }
+
+    -- Construct tag submenus ("move" and "add")
+    ------------------------------------------------------------
+    local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
+    local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t)  end, style)
+
+    -- Create menu
+    ------------------------------------------------------------
+    self.menu = redmenu({
+        hide_timeout = 1,
+        theme = style.menu,
+        items = {
+            { widget = actionline },
+            menusep,
+            { "Move to tag", { items = movemenu_items, theme = style.tagmenu } },
+            { "Add to tag",  { items = addmenu_items,  theme = style.tagmenu } },
+            menusep,
+            { widget = stateline }
+        }
+    })
+
+    -- Widget update functions
+    --------------------------------------------------------------------------------
+    function self:update(c)
+        if self.menu.wibox.visible then
+            stateboxes_update(c, state_icons, stateboxes)
+            tagmenu_update(c, self.menu, { 1, 2 }, style)
+        end
+    end
+
+    -- Signals setup
+    --------------------------------------------------------------------------------
+    local client_signals = {
+        "property::ontop", "property::floating", "property::below", "property::maximized",
+        "tagged", "untagged"  -- refresh tagmenu when client's tags change
+    }
+    for _, sg in ipairs(client_signals) do
+        client.connect_signal(sg, function() self:update(last.client) end)
+    end
+end
+
+-- Show window menu widget
+-----------------------------------------------------------------------------------------------------------------------
+function clientmenu:show(c)
+
+    -- toggle menu
+    if self.menu.wibox.visible and c == last.client and mouse.screen == last.screen  then
+        self.menu:hide()
+    else
+        last.client = c
+        last.screen = mouse.screen
+        self.menu:show({ coords = coords_calc(self.menu) })
+
+        if self.menu.hidetimer.started then self.menu.hidetimer:stop() end
+        self:update(c)
+    end
+end
+
+return setmetatable(clientmenu, clientmenu.mt)


### PR DESCRIPTION
### Please note

I made this widget primarily for my own use case but thought I'd try providing it upstream. Feel free to reject it if you see no use for it or if you think it does not fit into the idea of redflat.

I tried my best matching the code style and quality to the existing widgets. If there's any issue with the code I'm always open for suggestions. You don't have to pull this right away.

Please tell me if such addition would be of interest for you.

## Preface

Being a hybrid mouse/keyboard user and preferably using full size titlebars on my desktop system, I often found myself longing for a way to manage clients (especially close/minimize) by mouse without traveling the whole way down to the tasklist.

## Description

This new float (widget) introduces a new stand-alone popup menu that partly mimics the `tasklist.winmenu`. Instead of the client's name it shows two big buttons for minimize and close respectively, which are easy to access. Those two buttons will also make the menu hide upon press in contrast to the existing menu elements.

It is useful for:
- titlebar right-click popup (full size titlebars especially)
- custom keybind shortcut to popup at cursor position for active client

![clientmenu](https://user-images.githubusercontent.com/1408105/32409825-90c0dd72-c1b3-11e7-9116-a1343c067198.gif)

I borrowed some code from the `redflat.widget.tasklist.winmenu` widget but made a stand-alone float. It therefore has some code duplication with `redflat.widget.tasklist.winmenu` obviously.

## Example config for colorless

If you want to try it out, this menu can be integrated very easily into existing themes. It works well by simply copying the style config from the `tasklist.winmenu`. Below is an example for the `colorless` config and theme to use it as a titlebar right-click popup menu.

Diff for `colorless/titlebar-config.lua`:

    @@ -8,6 +8,7 @@ local wibox = require("wibox")
     
     -- local redflat = require("redflat")
     local redtitle = require("redflat.titlebar")
    +local clientmenu = require("redflat.float.clientmenu")
     
     -- Initialize tables and vars for module
     -----------------------------------------------------------------------------------------------------------------------
    @@ -23,6 +24,13 @@ local function title_buttons(c)
                                    client.focus = c;  c:raise()
                                    awful.mouse.client.move(c)
                            end
    +               ),
    +               awful.button(
    +                       { }, 3,
    +                       function()
    +                               client.focus = c;  c:raise()
    +                               clientmenu:show(c)
    +                       end
                    )
            )
     end
    @@ -50,6 +58,8 @@ function titlebar:init(args)
            style.light = args.light or redtitle.get_style()
            style.full = args.full or { size = 28, icon = { size = 25, gap = 0, angle = 0.5 } }
     
    +       clientmenu:init()
    +
            client.connect_signal(
                    "request::titlebars",
                    function(c)

Diff for `themes/colorless/theme.lua`:

    @@ -332,6 +332,19 @@ theme.widget.tasklist.winmenu.icon = {
            maximized            = theme.path .. "/common/window_control/maximized.svg",
     }
     
    +-- Clientmenu
    +------------------------------------------------------------
    +theme.widget.clientmenu = {
    +       micon          = theme.icon,
    +       color          = theme.color,
    +       actionline     = { height = 28 },
    +       layout_icon    = theme.widget.layoutbox.icon,
    +       menu           = theme.widget.tasklist.winmenu.menu,
    +       state_iconsize = theme.widget.tasklist.winmenu.state_iconsize,
    +       tagmenu        = theme.widget.tasklist.winmenu.tagmenu,
    +       icon           = theme.widget.tasklist.winmenu.icon,
    +}
    +
     -- task aliases
     theme.widget.tasklist.appnames = {}
     theme.widget.tasklist.appnames["Firefox"             ] = "FIFOX"