### PR TITLE
Initialize player's properties via dbus method call

### DIFF
--- a/float/player.lua
+++ b/float/player.lua
@@ -33,6 +33,10 @@ local dbus_get = dbus_mpris
                  .. "org.freedesktop.DBus.Properties.Get "
                  .. "string:'org.mpris.MediaPlayer2.Player' %s"
 
+local dbus_getall = dbus_mpris
+                    .. "org.freedesktop.DBus.Properties.GetAll "
+                    .. "string:'org.mpris.MediaPlayer2.Player'"
+
 local dbus_set = dbus_mpris
                  .. "org.freedesktop.DBus.Properties.Set "
                  .. "string:'org.mpris.MediaPlayer2.Player' %s"
@@ -100,6 +104,7 @@ function player:init(args)
 
 	-- dbus vars
 	self.command = {
+		get_all      = string.format(dbus_getall, _player),
 		get_position = string.format(dbus_get, _player, "string:'Position'"),
 		set_volume   = string.format(dbus_set, _player, "string:'Volume' variant:double:"),
 		action       = string.format(dbus_action, _player),
@@ -293,6 +298,51 @@ function player:init(args)
 	-- Run dbus servise
 	--------------------------------------------------------------------------------
 	if not self.listening then self:listen() end
+	self:initialize_info()
+end
+
+-- Initialize all properties via dbus call
+-- should be called only once for initialization before the dbus signals trigger the updates
+-----------------------------------------------------------------------------------------------------------------------
+function player:initialize_info()
+	awful.spawn.easy_async(
+		self.command.get_all,
+		function(output, _, _, exit_code)
+
+			local data = { Metadata = {} }
+
+			local function parse_dbus_value(ident)
+				local regex = "(" .. ident .. ")%s+([a-z0-9]+)%s+(.-)%s-%)\n"
+				_, _, value = output:match(regex)
+
+				-- check for int64 type field
+				int64_val = value:match("int64%s+(%d+)")
+				if int64_val then return tonumber(int64_val) end
+
+				-- check for double type field
+				double_val = value:match("double%s+([%d.]+)")
+				if double_val then return tonumber(double_val) end
+
+				-- check for array type field as table, extract first entry only
+				array_val = value:match("array%s%[%s+([^%],]+)")
+				if array_val then return { array_val } end
+
+				return value
+			end
+
+			if exit_code == 0 then
+				data.Metadata["xesam:title"]  = parse_dbus_value("xesam:title")
+				data.Metadata["xesam:artist"] = parse_dbus_value("xesam:artist")
+				data.Metadata["xesam:album"]  = parse_dbus_value("xesam:album")
+				data.Metadata["mpris:artUrl"] = parse_dbus_value("mpris:artUrl")
+				data.Metadata["mpris:length"] = parse_dbus_value("mpris:length")
+				data["Volume"]                = parse_dbus_value("Volume")
+				data["Position"]              = parse_dbus_value("Position")
+				data["PlaybackStatus"]        = parse_dbus_value("PlaybackStatus")
+				self:update_from_metadata(data)
+			end
+		end
+	)
 end
 
 -- Player playback control
@@ -345,6 +395,65 @@ function player:show(geometry)
 	end
 end
 
+-- Update property values from received metadata
+-----------------------------------------------------------------------------------------------------------------------
+function player:update_from_metadata(data)
+	-- empty call
+	if not data then return end
+
+	-- set track info if playing
+	if data.Metadata then
+		-- set song title
+		self.box.title:set_text(data.Metadata["xesam:title"] or "Unknown")
+
+		-- set album or artist info
+
+		self.info.artist = data.Metadata["xesam:artist"] and data.Metadata["xesam:artist"][1] or "Unknown"
+		self.info.album  = data.Metadata["xesam:album"] or "Unknown"
+		self.update_artist()
+
+		-- set cover art
+		if data.Metadata["mpris:artUrl"] then
+			local image = string.match(data.Metadata["mpris:artUrl"], "file://(.+)")
+			self.box.image:set_color(nil)
+			self.box.image:set_image(decodeURI(image))
+		else
+			-- reset to generic icon if no cover available
+			self.box.image:set_image(self.style.icon.cover)
+		end
+
+		-- track length
+		if data.Metadata["mpris:length"] then self.last.length = data.Metadata["mpris:length"] end
+	end
+
+	if data.PlaybackStatus then
+
+		-- check player status and set suitable play/pause button image
+		local state = data.PlaybackStatus == "Playing" and "pause" or "play"
+		self.set_play_button(state)
+		self.last.status = data.PlaybackStatus
+
+		-- stop/start update timer
+		if data.PlaybackStatus == "Playing" then
+			if self.wibox.visible then self.updatetimer:start() end
+		else
+			if self.updatetimer.started then self.updatetimer:stop() end
+			self:update()
+		end
+
+		-- clear track info if stoppped
+		if data.PlaybackStatus == "Stopped" then
+			self.clear_info()
+		end
+	end
+
+	-- volume
+	if data.Volume then
+		self.volume:set_value(data.Volume)
+		self.last.volume = data.Volume
+	end
+end
+
 -- Dbus signal setup
 -- update some info which avaliable from dbus signal
 -----------------------------------------------------------------------------------------------------------------------
@@ -356,60 +465,7 @@ function player:listen()
 	)
 	dbus.connect_signal("org.freedesktop.DBus.Properties",
 		function (_, _, data)
-
-			-- empty call
-			if not data then return end
-
-			-- set track info if playing
-			if data.Metadata then
-				-- set song title
-				self.box.title:set_text(data.Metadata["xesam:title"] or "Unknown")
-
-				-- set album or artist info
-				self.info.artist = data.Metadata["xesam:artist"] and data.Metadata["xesam:artist"][1] or "Unknown"
-				self.info.album  = data.Metadata["xesam:album"] or "Unknown"
-				self.update_artist()
-
-				-- set cover art
-				if data.Metadata["mpris:artUrl"] then
-					local image = string.match(data.Metadata["mpris:artUrl"], "file://(.+)")
-					self.box.image:set_color(nil)
-					self.box.image:set_image(decodeURI(image))
-				else
-					-- reset to generic icon if no cover available
-					self.box.image:set_image(self.style.icon.cover)
-				end
-
-				-- track length
-				if data.Metadata["mpris:length"] then self.last.length = data.Metadata["mpris:length"] end
-			end
-
-			if data.PlaybackStatus then
-
-				-- check player status and set suitable play/pause button image
-				local state = data.PlaybackStatus == "Playing" and "pause" or "play"
-				self.set_play_button(state)
-				self.last.status = data.PlaybackStatus
-
-				-- stop/start update timer
-				if data.PlaybackStatus == "Playing" then
-					if self.wibox.visible then self.updatetimer:start() end
-				else
-					if self.updatetimer.started then self.updatetimer:stop() end
-					self:update()
-				end
-
-				-- clear track info if stoppped
-				if data.PlaybackStatus == "Stopped" then
-					self.clear_info()
-				end
-			end
-
-			-- volume
-			if data.Volume then
-				self.volume:set_value(data.Volume)
-				self.last.volume = data.Volume
-			end
+			self:update_from_metadata(data)
 		end
 	)
 


### PR DESCRIPTION
## Outline

This patch set tackles two issues:

1. the mpris2 `player` widget info not being initialized at startup of awesome
2. the volume value only being retrieved when changed in the player

## Preface

Using multi-screen setup at my desk, I may have multiple restarts of awesome per day when plugging/unplugging the external screen to carry the device around. On startup of awesome the mpris2 dbus values of the `player` widget are not initialized - they are only slowly filled as the player emits the corresponding `PropertiesChanged` dbus signals. So as long as the track doesn't change, many of the widget's displays remain uninitialized.

## Details

The first commit in this patch set outsources the property extraction functionality for dbus replies into `update_from_metadata()`. This function is now additionally called by `initialize_info()`. The `initialize_info()` function makes a dbus `GetAll` call to initially grab all the available mpris2 properties from the player. Since the dbus implementation of awesome doesn't support dbus method calls, I had to manually parse the whole response. At least this was a good regex exercise :)

The second commit adds a volume retrieval to the `update_from_metadata()` function. With the player I use (Audacious), the volume only ever got updated when it was actually changed in the player. The new initialization is insufficient here because if the player gets started after awesome, the initialization will not trigger but the initial `PropertiesChanged` from Audacious after its startup will not contain the volume value either. The only choice I saw here was to explicitly grab the current volume in the `PropertiesChanged` signal handling if it is not part of the `data` supplied.

As always, your review and opinion are greatly appreciated!
