### PR TITLE
Fix player volume scrolling issues

### DIFF
--- a/float/player.lua
+++ b/float/player.lua
@@ -365,7 +365,7 @@ function player:change_volume(step)
 	if     v > 1 then v = 1
 	elseif v < 0 then v = 0 end
 
-	self.last.volume = nil
+	self.last.volume = v
 	awful.spawn.with_shell(self.command.set_volume .. v)
 end
 


### PR DESCRIPTION
This is a small but effective fix for `redflat.float.player` addressing two issues with the player's volume meter relating to mouse scrolling actions:

## Scrolling too fast

When scrolling up (i.e. calling `change_volume()`), the `self.last.volume = nil` is set and then the `command.set_volume` is spawned which will eventually result in a `PropertiesChanged` dbus signal that informs the widget about the new volume, finally refreshing `self.last.volume`. If scrolling too fast however, the next `change_volume()` is called *before* the `PropertiesChanged` signal reaches the widget. In this case `self.last.volume` is still `nil` and the `(self.last.volume or 0)` statement resolves to `0`, effectively resetting the volume to `0 + step`.

## Scrolling beyond 100%

On the last increment of volume, the `(self.last.volume or 0) + step` will resolve to `1`, reaching 100% volume. Again, `self.last.volume = nil` is executed but refreshed as soon as the dbus signal reaches the widget, which informs about a volume of `1`. However, if the `change_volume()` function is called subsequently (e.g. by scrolling further), the same procedure happens *except* for the dbus signal. Because the player already has a volume of `1` there is no change, thus the player might decide not to emit `PropertiesChanged` signal at all. In this case, `self.last.volume` is kept as `nil`. Any further calling of `change_volume()` will inevitably reset the volume in the same fasion as described in the first issue.