### PR TITLE
Menu handling improvements

### DIFF
--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -89,9 +89,9 @@ local function tagmenu_rebuild(menu, submenu_index, style)
 	for _, index in ipairs(submenu_index) do
 			local new_items
 			if index == 1 then
-				new_items = tagmenu_items(function(t) last.client:move_to_tag(t) clientmenu.menu:hide() end, style)
+				new_items = tagmenu_items(function(t) last.client:move_to_tag(t); clientmenu.menu:hide(); awful.layout.arrange(t.screen) end, style)
 			else
-				new_items = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
+				new_items = tagmenu_items(function(t) last.client:toggle_tag(t); awful.layout.arrange(t.screen) end, style)
 			end
 			menu.items[index].child:replace_items(new_items)
 	end
@@ -301,8 +301,8 @@ function clientmenu:init(style)
 
 	-- Construct tag submenus ("move" and "add")
 	------------------------------------------------------------
-	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t); clientmenu.menu:hide() end, style)
-	local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
+	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t); clientmenu.menu:hide(); awful.layout.arrange(t.screen) end, style)
+	local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t); awful.layout.arrange(t.screen) end, style)
 
 	-- Create menu
 	------------------------------------------------------------

--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -89,7 +89,7 @@ local function tagmenu_rebuild(menu, submenu_index, style)
 	for _, index in ipairs(submenu_index) do
 			local new_items
 			if index == 1 then
-				new_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
+				new_items = tagmenu_items(function(t) last.client:move_to_tag(t) clientmenu.menu:hide() end, style)
 			else
 				new_items = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
 			end
@@ -301,8 +301,8 @@ function clientmenu:init(style)
 
 	-- Construct tag submenus ("move" and "add")
 	------------------------------------------------------------
-	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
-	local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t)  end, style)
+	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t); clientmenu.menu:hide() end, style)
+	local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
 
 	-- Create menu
 	------------------------------------------------------------

--- a/menu.lua
+++ b/menu.lua
@@ -317,6 +317,7 @@ end
 -- @param args.coords Menu position defaulting to mouse.coords()
 --------------------------------------------------------------------------------
 function menu:show(args)
+	if self.wibox.visible then return end
 	local args = args or {}
 	local screen_index = mouse.screen
 

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -142,9 +142,9 @@ local function tagmenu_rebuild(menu, submenu_index, style)
 	for _, index in ipairs(submenu_index) do
 			local new_items
 			if index == 1 then
-				new_items = tagmenu_items(function(t) last.client:move_to_tag(t); redtasklist.winmenu.menu:hide() end, style)
+				new_items = tagmenu_items(function(t) last.client:move_to_tag(t); redtasklist.winmenu.menu:hide(); awful.layout.arrange(t.screen) end, style)
 			else
-				new_items = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
+				new_items = tagmenu_items(function(t) last.client:toggle_tag(t); awful.layout.arrange(t.screen) end, style)
 			end
 			menu.items[index].child:replace_items(new_items)
 	end
@@ -509,8 +509,8 @@ function redtasklist.winmenu:init(style)
 
 	-- Construct tag submenus ("move" and "add")
 	------------------------------------------------------------
-	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t); redtasklist.winmenu.menu:hide() end, style)
-	local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t)  end, style)
+	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t); redtasklist.winmenu.menu:hide(); awful.layout.arrange(t.screen) end, style)
+	local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t); awful.layout.arrange(t.screen)  end, style)
 
 	-- Create menu
 	------------------------------------------------------------

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -142,7 +142,7 @@ local function tagmenu_rebuild(menu, submenu_index, style)
 	for _, index in ipairs(submenu_index) do
 			local new_items
 			if index == 1 then
-				new_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
+				new_items = tagmenu_items(function(t) last.client:move_to_tag(t); redtasklist.winmenu.menu:hide() end, style)
 			else
 				new_items = tagmenu_items(function(t) last.client:toggle_tag(t) end, style)
 			end
@@ -449,8 +449,8 @@ function redtasklist.winmenu:init(style)
 
 	-- Window managment functions
 	--------------------------------------------------------------------------------
-	local close    = function() last.client:kill() end
-	local minimize = function() last.client.minimized = not last.client.minimized end
+	local close    = function() last.client:kill(); redtasklist.winmenu.menu:hide() end
+	local minimize = function() last.client.minimized = not last.client.minimized; redtasklist.winmenu.menu:hide() end
 	local maximize = function() last.client.maximized = not last.client.maximized end
 
 	-- Create array of state icons
@@ -509,7 +509,7 @@ function redtasklist.winmenu:init(style)
 
 	-- Construct tag submenus ("move" and "add")
 	------------------------------------------------------------
-	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t) end, style)
+	local movemenu_items = tagmenu_items(function(t) last.client:move_to_tag(t); redtasklist.winmenu.menu:hide() end, style)
 	local addmenu_items  = tagmenu_items(function(t) last.client:toggle_tag(t)  end, style)
 
 	-- Create menu


### PR DESCRIPTION
# Menu handling improvements

This patch set makes the following changes:

- `clientmenu` now hides upon "Move to tag" action
  - it automatically hides upon close and minimize already
- the window menu of `tasklist` now hides upon:
  - "Move to tag" action
  - close action
  - minimize action
- `menu` does not add further packs to the `hotkey` helper when `show()` is called on an already visible menu
    - fixes: opening a menu, hovering "Add to tag" and then clicking on "Add to tag" would effectively call `show()` twice subsequently which led to the hotkey helper still showing menu hints even after the menu was closed
- any "Move to tag" or "Add to tag" action will now rearrange the layout


## Remarks regarding the menu hiding on action

I found it very counter-intuitive for menus to still stay visible whenever the corresponding client window vanishes from the screen (e.g. due to minimize or "Move to tag"). That's why I added the `hide()` call to destructive actions.

This has one exception though: when a client is assigned to multiple tags (*including* the current one) and then the "Add to tag" option is used to *uncheck* the current tag. This leads to the window vanishing from the current layout as well. However, I have not yet integrated a `hide()` call for this.

Hiding the menu in this case as well would be in coherence with the other changes since the window also disappears in this case - but would require a check within the "Add to tag" action whether the window has actually left the current layout (= visible tags) or not.

I'm still on the fence about this one. I would appreciate your feedback and input on this.


## Remarks about the layout rearrange call

Any "Move to tag" or "Add to tag" actions now include a `awful.layout.arrange(t.screen)` call. This is to fix the following bug:

- open multiple windows on tag **A** which is using a tiling layout (e.g. "Right Tile")
- use the "Add to tag" menu option for one of the windows and add it to tag **B**
- open the menu for the same window again and use the "Add to tag" menu to **uncheck** the current tag **A**
- the window will vanish from the current tiling layout **but will leave an empty gap**
- the gap is only filled (= layout rearranged) when another window is clicked