### PR TITLE
Small fixes/improvements

### DIFF
--- a/float/player.lua
+++ b/float/player.lua
@@ -317,6 +317,7 @@ function player:initialize_info()
 			local function parse_dbus_value(ident)
 				local regex = "(" .. ident .. ")%s+([a-z0-9]+)%s+(.-)%s-%)\n"
 				_, _, value = output:match(regex)
+				if not value then return nil end
 
 				-- check for int64 type field
 				int64_val = value:match("int64%s+(%d+)")

--- a/service/navigator.lua
+++ b/service/navigator.lua
@@ -21,7 +21,7 @@ local rednotify = require("redflat.float.notify")
 
 -- Initialize tables and vars for module
 -----------------------------------------------------------------------------------------------------------------------
-local navigator = { action = {}, data = {} }
+local navigator = { action = {}, data = {}, active = false }
 
 navigator.ignored = { "dock", "splash", "desktop" }
 
@@ -231,6 +231,24 @@ function navigator:init()
 	function self.hilight.hide()
 		for i, c in ipairs(self.cls) do self.data[i].widget:set_alert(false) end
 	end
+
+	-- close the navigator on tag switch
+	tag.connect_signal('property::selected',
+		function(t)
+			if navigator.active then
+				self:close()
+			end
+		end
+	)
+
+	-- update navigator if new client spawns
+	client.connect_signal('manage',
+		function(c)
+			if navigator.active then
+				self:restart()
+			end
+		end
+	)
 end
 
 function navigator:run()
@@ -284,6 +302,8 @@ function navigator:run()
 			self.style.keytip.base.exit and function() redflat.layout.common.action.exit() end -- fix this?
 		)
 	end
+
+	navigator.active = true
 end
 
 function navigator:close()
@@ -297,6 +317,8 @@ function navigator:close()
 	local l = client.focus and awful.layout.get(client.focus.screen)
 	if l and l.cleanup then l.cleanup() end
 	self.cls = {}
+
+	navigator.active = false
 end
 
 function navigator:restart()

--- a/widget/minitray.lua
+++ b/widget/minitray.lua
@@ -25,7 +25,6 @@ local redutil = require("redflat.util")
 local dotcount = require("redflat.gauge.graph.dots")
 local tooltip = require("redflat.float.tooltip")
 
-
 -- Initialize tables and wibox
 -----------------------------------------------------------------------------------------------------------------------
 local minitray = { widgets = {}, mt = {} }
@@ -70,23 +69,22 @@ function minitray:init(style)
 	-- Set tray
 	--------------------------------------------------------------------------------
 	local l = wibox.layout.align.horizontal()
-	l:set_middle(wibox.widget.systray())
+	local tray = wibox.widget.systray()
+	l:set_middle(tray)
 	self.wibox:set_widget(l)
+
+	-- update geometry if tray icons change
+	tray:connect_signal('widget::redraw_needed', function()
+		self:update_geometry()
+	end)
 end
 
 -- Show/hide functions for wibox
 -----------------------------------------------------------------------------------------------------------------------
 
--- Show
+-- Update Geometry
 --------------------------------------------------------------------------------
-function minitray:show()
-
-	-- Force upsdate all widgets
-	------------------------------------------------------------
-	for _, w in ipairs(self.widgets) do
-		w:update()
-	end
-
+function minitray:update_geometry()
 	-- Set wibox size and position
 	------------------------------------------------------------
 	local items = awesome.systray()
@@ -99,6 +97,19 @@ function minitray:show()
 		awful.placement.under_mouse(self.wibox)
 	end
 	redutil.placement.no_offscreen(self.wibox, self.screen_gap, mouse.screen.workarea)
+end
+
+-- Show
+--------------------------------------------------------------------------------
+function minitray:show()
+
+	-- Force update all widgets
+	------------------------------------------------------------
+	for _, w in ipairs(self.widgets) do
+		w:update()
+	end
+
+	self:update_geometry()
 
 	-- Show
 	------------------------------------------------------------

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -38,11 +38,12 @@ local dfparser = require("redflat.service.dfparser")
 local redtasklist = { filter = {}, winmenu = {}, tasktip = {}, action = {}, mt = {}, }
 
 local last = {
-	client      = nil,
-	group       = nil,
-	client_list = nil,
-	screen      = mouse.screen,
-	tag_screen  = mouse.screen
+	client         = nil,
+	group          = nil,
+	client_list    = nil,
+	screen         = mouse.screen,
+	tag_screen     = mouse.screen,
+	screen_clients = {}
 }
 
 -- Generate default theme vars
@@ -675,7 +676,7 @@ function redtasklist.new(args, style)
 		local clients = visible_clients(filter, cs)
 		local client_groups = group_task(clients, style.need_group)
 
-		last.sorted_list = sort_list(client_groups)
+		last.screen_clients[cs] = sort_list(client_groups)
 
 		tasklist_construct(client_groups, tasklist, data, args.buttons, style)
 	end
@@ -763,12 +764,12 @@ end
 
 -- switch to next task
 function redtasklist.action.switch_next(args)
-	switch_focus(last.sorted_list)
+	switch_focus(last.screen_clients[mouse.screen])
 end
 
 -- switch to previous task
 function redtasklist.action.switch_prev(args)
-	switch_focus(last.sorted_list, true)
+	switch_focus(last.screen_clients[mouse.screen], true)
 end
 
 


### PR DESCRIPTION
This Pull Request contains the following fixes/improvements:

- fixes an issue in the `player` where inexistent MPRIS values will abort the metadata initialization at startup
- the `navigator` will close itself if the tag changes
  - up until now it was possible to change the tag with the mouse in the `taglist` but the `navigator` would still show the decors for the previous tag
- the `navigator` will refresh itself if a new client spawns
  - execute `sleep 2; xterm` and open up the `navigator` - with this change, the newly spawned `xterm` will be automatically included in the navigation upon arrival
- the `minitray` will now update its geometry if the system tray entries change (applications appear or vanish from the system tray)
- scrolling the mouse wheel to switch windows on the `tasklist` now has multi-monitor support
  - fixes an issue where scrolling on a `tasklist` would cycle through windows on a different screen