### PR TITLE
Omit clients with skip_taskbar from taglist widget

### DIFF
--- a/widget/taglist.lua
+++ b/widget/taglist.lua
@@ -55,7 +55,9 @@ local function get_state(t)
 	for _, c in pairs(client_list) do
 		state.focus     = state.focus or client.focus == c
 		state.urgent    = state.urgent or c.urgent
-		table.insert(state.list, { focus = client.focus == c, urgent = c.urgent, minimized = c.minimized })
+		if not c.skip_taskbar then
+			table.insert(state.list, { focus = client.focus == c, urgent = c.urgent, minimized = c.minimized })
+		end
 	end
 
 	state.active = t.selected


### PR DESCRIPTION
I noticed that clients which have their `skip_taskbar` property set to `true` aren't shown on the `tasklist` but they do appear as gauges/indicators in the `taglist` widget, which leads to a confusing mismatch. This patch adds a check for the `skip_taskbar` property and omits matching clients from the `taglist` indicators as well.

As usual, feel free to reject or adjust as you see fit.