### PR TITLE
Use set_markup for escaped strings

### DIFF
--- a/float/apprunner.lua
+++ b/float/apprunner.lua
@@ -115,12 +115,12 @@ local function construct_item(style)
 		local args = args or {}
 
 		local name_text = awful.util.escape(args.Name) or ""
-		item.name:set_text(name_text)
+		item.name:set_markup(name_text)
 
 		local comment_text = args.Comment and awful.util.escape(args.Comment)
 		                     or args.Name and "No description"
 		                     or ""
-		item.comment:set_text(comment_text)
+		item.comment:set_markup(comment_text)
 
 		item.icon:set_image(args.icon_path or style.dimage)
 		item.icon:set_visible((args.Name))

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -416,7 +416,7 @@ local function construct_tasktip(c_group, layout, data, buttons, style)
 			data[i] = line
 		end
 
-		line:set_text(awful.util.escape(c.name))
+		line:set_text(awful.util.escape(c.name) or "Untitled")
 		tb_w, tb_h = line.tb:get_preferred_size()
 
 		-- set state highlight only for grouped tasks

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -326,7 +326,7 @@ local function tasktip_line(style)
 
 	-- tasktip line metods
 	function line:set_text(text)
-		line.tb:set_text(text)
+		line.tb:set_markup(text)
 		line.field:set_fg(style.color.text)
 		line.field:set_bg(style.color.wibox)
 	end


### PR DESCRIPTION
The current way to retrieve and set the client's name in the `tasklist`'s tooltips is like this:

https://github.com/worron/redflat/blob/33de1187a51e8ff4c6da10874cb6336690e32cb9/widget/tasklist.lua#L419

The problem here is that whenever a window title uses special characters they get escaped like in HTML. For example, if I open a file manager window in a folder named `a & b : c ?  >.<`, the tooltip label will be displayed as `a &amp; b : c ? &gt;.&lt;`.

The titlebar caption (when using full size titlebars) however is displayed correctly, since the text seems to get unescaped during the `set_markup()` command which is used there instead of `set_text()`:

https://github.com/worron/redflat/blob/33de1187a51e8ff4c6da10874cb6336690e32cb9/titlebar.lua#L329

The `escape()` is also used in [apprunner](https://github.com/worron/redflat/blob/33de1187a51e8ff4c6da10874cb6336690e32cb9/float/apprunner.lua#L117) with `set_text()` for `name` and `comment`, so it might cause problems there as well. On the other hand, for [menu](https://github.com/worron/redflat/blob/33de1187a51e8ff4c6da10874cb6336690e32cb9/menu.lua#L534) and [appswitcher](https://github.com/worron/redflat/blob/33de1187a51e8ff4c6da10874cb6336690e32cb9/float/appswitcher.lua#L412) it is already used with `set_markup()` and shouldn't cause problems.

I adjusted the tasklist's tooltip and apprunner code to use `set_markup()` instead of `set_text()` for escaped strings.

