### PR TITLE
Customizable hide for all client menu actions

### DIFF
--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -53,7 +53,14 @@ local function default_style()
 		action_iconsize = { width = 18, height = 18 },
 		sep_margin      = { horizontal = { 3, 3, 5, 5 }, vertical = { 3, 3, 3, 3 } },
 		tagmenu         = { icon_margin = { 2, 2, 2, 2 } },
-		hide_action     = { move = true, add = false, min = true, floating = false, sticky = false, ontop = false, below = false, maximized = false },
+		hide_action     = { move = true,
+		                    add = false,
+		                    min = true,
+		                    floating = false,
+		                    sticky = false,
+		                    ontop = false,
+		                    below = false,
+		                    maximized = false },
 		color           = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040", highlight = "#eeeeee" },
 	}
 	style.menu = {

--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -53,7 +53,7 @@ local function default_style()
 		action_iconsize = { width = 18, height = 18 },
 		sep_margin      = { horizontal = { 3, 3, 5, 5 }, vertical = { 3, 3, 3, 3 } },
 		tagmenu         = { icon_margin = { 2, 2, 2, 2 } },
-		hide_action     = { move = true, add = false },
+		hide_action     = { move = true, add = false, min = true, floating = false, sticky = false, ontop = false, below = false, maximized = false },
 		color           = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040", highlight = "#eeeeee" },
 	}
 	style.menu = {
@@ -190,7 +190,6 @@ local function action_line_construct(setup_layout, style)
 		actionbox:buttons(awful.util.table.join(awful.button({}, 1,
 			function()
 				action()
-				clientmenu.menu:hide()  -- close menu on action
 			end
 		)))
 		actionbox:connect_signal("mouse::enter",
@@ -213,6 +212,7 @@ local function action_line_construct(setup_layout, style)
 		style.icon.minimize,
 		function()
 			last.client.minimized = not last.client.minimized
+			if style.hide_action["min"] then clientmenu.menu:hide() end
 		end
 	)
 	setup_layout:set_first(minimize_box)
@@ -225,6 +225,7 @@ local function action_line_construct(setup_layout, style)
 		style.icon.close,
 		function()
 			last.client:kill()
+			clientmenu.menu:hide()
 		end
 	)
 	setup_layout:set_third(close_box)
@@ -256,7 +257,7 @@ function clientmenu:init(style)
 	local function icon_table_generator_prop(property)
 		return {
 			icon      = style.icon[property] or style.icon.unknown,
-			action    = function() last.client[property] = not last.client[property] end,
+			action    = function() last.client[property] = not last.client[property]; self.hide_check(property) end,
 			indicator = function(c) return c[property] end
 		}
 	end

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -73,7 +73,15 @@ local function default_style()
 		state_iconsize = { width = 20, height = 20 },
 		sep_margin     = { 3, 3, 5, 5 },
 		tagmenu        = { icon_margin = { 2, 2, 2, 2 } },
-		hide_action    = { min = true, move = true, max = false, add = false, floating = false, sticky = false, ontop = false, below = false, maximized = false },
+		hide_action    = { min = true,
+		                   move = true,
+		                   max = false,
+		                   add = false,
+		                   floating = false,
+		                   sticky = false,
+		                   ontop = false,
+		                   below = false,
+		                   maximized = false },
 		color          = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040" }
 	}
 	style.tasktip = {

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -73,7 +73,7 @@ local function default_style()
 		state_iconsize = { width = 20, height = 20 },
 		sep_margin     = { 3, 3, 5, 5 },
 		tagmenu        = { icon_margin = { 2, 2, 2, 2 } },
-		hide_action    = { min = true, move = true, max = false, add = false },
+		hide_action    = { min = true, move = true, max = false, add = false, floating = false, sticky = false, ontop = false, below = false, maximized = false },
 		color          = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040" }
 	}
 	style.tasktip = {
@@ -455,7 +455,7 @@ function redtasklist.winmenu:init(style)
 		if style.hide_action[action] then self.menu:hide() end
 	end
 
-	local close    = function() last.client:kill() end
+	local close    = function() last.client:kill(); self.menu:hide() end
 	local minimize = function() last.client.minimized = not last.client.minimized; self.hide_check("min") end
 	-- local maximize = function() last.client.maximized = not last.client.maximized; self.hide_check("max")end
 
@@ -465,7 +465,7 @@ function redtasklist.winmenu:init(style)
 	local function icon_table_ganerator(property)
 		return {
 			icon      = style.icon[property] or style.icon.unknown,
-			action    = function() last.client[property] = not last.client[property] end,
+			action    = function() last.client[property] = not last.client[property]; self.hide_check(property) end,
 			indicator = function(c) return c[property] end
 		}
 	end


### PR DESCRIPTION
This patch concludes https://github.com/worron/redflat/commit/b80f5c07f59ba2da29e2f076bb69c2e512a955cc, where we started to make the hide/nohide behavior in the client menus customizable.

- this patch introduces no changes to default behavior (except for close, see below)
- adds new customizable hide/nohide for the following actions:
   - property actions for both menus
   - the minimize for `clientmenu`
- for `tasklist` menu, adds a fixed hide call for the close action (non-customizable)\*

\* this attempts to fix an issue where the menu would still be kept open after clicking on close when the corresponding client freezes and does not respond to kill.