### PR TITLE
Small player fixes

### DIFF
--- a/float/player.lua
+++ b/float/player.lua
@@ -422,8 +422,10 @@ function player:update_from_metadata(data)
 		local has_cover = false
 		if data.Metadata["mpris:artUrl"] then
 			local image = string.match(data.Metadata["mpris:artUrl"], "file://(.+)")
-			self.box.image:set_color(nil)
-			has_cover = self.box.image:set_image(decodeURI(image))
+			if image then
+				self.box.image:set_color(nil)
+				has_cover = self.box.image:set_image(decodeURI(image))
+			end
 		end
 		if not has_cover then
 			-- reset to generic icon if no cover available

--- a/float/player.lua
+++ b/float/player.lua
@@ -419,12 +419,15 @@ function player:update_from_metadata(data)
 		self.update_artist()
 
 		-- set cover art
+		local has_cover = false
 		if data.Metadata["mpris:artUrl"] then
 			local image = string.match(data.Metadata["mpris:artUrl"], "file://(.+)")
 			self.box.image:set_color(nil)
-			self.box.image:set_image(decodeURI(image))
-		else
+			has_cover = self.box.image:set_image(decodeURI(image))
+		end
+		if not has_cover then
 			-- reset to generic icon if no cover available
+			self.box.image:set_color(self.style.color.gray)
 			self.box.image:set_image(self.style.icon.cover)
 		end
 


### PR DESCRIPTION
This adds some fixes to the `player` widget:

- only attempt to load the cover image if it is a local file (= `file://` regex succeeds)
  - players like Spotify use web URLs for cover images, which are also propagated via `mpris:artUrl` on the D-Bus, which led to a spam of error messages because the `file://` regex returning `nil`
- reset the cover image if the `self.box.image:set_image()` call fails
  - for some files Audacious may generate broken `artUrl` files if the cover image in the mp3 is malformed, which led to an empty `player` widget due to the `self.box.image` not being reset
- when resetting the cover images, reset the color to `style.color.gray`
  - up until now, it was not specified and set to some default color `#A0A0A0` which was not part of the style defintiion