### PR TITLE
Small fixes/improvements 2

### DIFF
--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -120,24 +120,28 @@ local function tagmenu_update(c, menu, submenu_index, style)
 			-- set layout icon for every tag
 			local l = awful.layout.getname(awful.tag.getproperty(t, "layout"))
 
-			for _, index in ipairs(submenu_index) do
-				if menu.items[index].child.items[k].icon then
-					menu.items[index].child.items[k].icon:set_image(style.layout_icon[l] or style.layout_icon.unknown)
-				end
-			end
-
-			-- set "checked" icon if tag active for given client
-			-- otherwise set empty icon
+			local check_icon = style.micon.blank
 			if c then
 				local client_tags = c:tags()
-				local check_icon = awful.util.table.hasitem(client_tags, t) and style.micon.check
-				                   or style.micon.blank
+				check_icon = awful.util.table.hasitem(client_tags, t) and style.micon.check or check_icon
+			end
 
-				for _, index in ipairs(submenu_index) do
-					if menu.items[index].child.items[k].right_icon then
-						menu.items[index].child.items[k].right_icon:set_image(check_icon)
+			for _, index in ipairs(submenu_index) do
+				local submenu = menu.items[index].child
+				if submenu.items[k].icon then
+					submenu.items[k].icon:set_image(style.layout_icon[l] or style.layout_icon.unknown)
+				end
+
+				-- set "checked" icon if tag active for given client
+				-- otherwise set empty icon
+				if c then
+					if submenu.items[k].right_icon then
+						submenu.items[k].right_icon:set_image(check_icon)
 					end
 				end
+
+				-- update position of any visible submenu
+				if submenu.wibox.visible then submenu:show() end
 			end
 		end
 	end

--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -70,7 +70,7 @@ local function default_style()
 		nohide       = true
 	}
 
-	return redutil.table.merge(style, redutil.table.check(beautiful, "widget.clientmenu") or {})
+	return redutil.table.merge(style, redutil.table.check(beautiful, "float.clientmenu") or {})
 end
 
 -- Support functions

--- a/menu.lua
+++ b/menu.lua
@@ -317,12 +317,12 @@ end
 -- @param args.coords Menu position defaulting to mouse.coords()
 --------------------------------------------------------------------------------
 function menu:show(args)
-	if self.wibox.visible then return end
 	local args = args or {}
 	local screen_index = mouse.screen
+	set_coords(self, screen_index, args.coords)
+	if self.wibox.visible then return end
 
 	-- show menu
-	set_coords(self, screen_index, args.coords)
 	awful.keygrabber.run(self._keygrabber)
 	self.wibox.visible = true
 	if self.theme.select_first or self.parent then self:item_enter(1) end

--- a/service/navigator.lua
+++ b/service/navigator.lua
@@ -249,6 +249,15 @@ function navigator:init()
 			end
 		end
 	)
+
+	-- update navigator if a client gets minimized or restored
+	client.connect_signal('property::minimized',
+		function(c)
+			if navigator.active then
+				self:restart()
+			end
+		end
+	)
 end
 
 function navigator:run()

--- a/widget/taglist.lua
+++ b/widget/taglist.lua
@@ -51,17 +51,19 @@ end
 local function get_state(t)
 	local state = { focus = false, urgent = false, list = {} }
 	local client_list = t:clients()
+	local client_count = 0
 
 	for _, c in pairs(client_list) do
 		state.focus     = state.focus or client.focus == c
 		state.urgent    = state.urgent or c.urgent
 		if not c.skip_taskbar then
+			client_count = client_count + 1
 			table.insert(state.list, { focus = client.focus == c, urgent = c.urgent, minimized = c.minimized })
 		end
 	end
 
 	state.active = t.selected
-	state.occupied = #client_list > 0 and not (#client_list == 1 and state.focus)
+	state.occupied = client_count > 0 and not (client_count == 1 and state.focus)
 	state.text = string.upper(t.name)
 	state.layout = awful.tag.getproperty(t, "layout")
 

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -391,8 +391,6 @@ local function tasklist_construct(client_groups, layout, data, buttons, style)
 	layout:set_max_widget_size(task_full_width)
 	layout:set_forced_width(task_full_width * #client_groups)
 
-	table.sort(client_groups, client_group_sort_by_class)
-
 	-- construct tasklist
 	for i, c_group in ipairs(client_groups) do
 		local task
@@ -710,6 +708,7 @@ function redtasklist.new(args, style)
 		local clients = visible_clients(filter, cs)
 		local client_groups = group_task(clients, style.need_group)
 
+		table.sort(client_groups, client_group_sort_by_class)
 		last.screen_clients[cs] = sort_list(client_groups)
 
 		tasklist_construct(client_groups, tasklist, data, args.buttons, style)

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -176,24 +176,28 @@ local function tagmenu_update(c, menu, submenu_index, style)
 			-- set layout icon for every tag
 			local l = awful.layout.getname(awful.tag.getproperty(t, "layout"))
 
-			for _, index in ipairs(submenu_index) do
-				if menu.items[index].child.items[k].icon then
-					menu.items[index].child.items[k].icon:set_image(style.layout_icon[l] or style.layout_icon.unknown)
-				end
-			end
-
-			-- set "checked" icon if tag active for given client
-			-- otherwise set empty icon
+			local check_icon = style.micon.blank
 			if c then
 				local client_tags = c:tags()
-				local check_icon = awful.util.table.hasitem(client_tags, t) and style.micon.check
-				                   or style.micon.blank
+				check_icon = awful.util.table.hasitem(client_tags, t) and style.micon.check or check_icon
+			end
 
-				for _, index in ipairs(submenu_index) do
-					if menu.items[index].child.items[k].right_icon then
-						menu.items[index].child.items[k].right_icon:set_image(check_icon)
+			for _, index in ipairs(submenu_index) do
+				local submenu = menu.items[index].child
+				if submenu.items[k].icon then
+					submenu.items[k].icon:set_image(style.layout_icon[l] or style.layout_icon.unknown)
+				end
+
+				-- set "checked" icon if tag active for given client
+				-- otherwise set empty icon
+				if c then
+					if submenu.items[k].right_icon then
+						submenu.items[k].right_icon:set_image(check_icon)
 					end
 				end
+
+				-- update position of any visible submenu
+				if submenu.wibox.visible then submenu:show() end
 			end
 		end
 	end

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -374,6 +374,10 @@ local function switch_focus(list, is_reverse)
 	list[index]:raise()
 end
 
+local function client_group_sort_by_class(a, b)
+	return a[1].class < b[1].class
+end
+
 -- Build or update tasklist.
 --------------------------------------------------------------------------------
 local function tasklist_construct(client_groups, layout, data, buttons, style)
@@ -382,6 +386,8 @@ local function tasklist_construct(client_groups, layout, data, buttons, style)
 	local task_full_width = style.width + style.task_margin[1] + style.task_margin[2]
 	layout:set_max_widget_size(task_full_width)
 	layout:set_forced_width(task_full_width * #client_groups)
+
+	table.sort(client_groups, client_group_sort_by_class)
 
 	-- construct tasklist
 	for i, c_group in ipairs(client_groups) do


### PR DESCRIPTION
* `navigator` will refresh itself if a client gets minimized or restored by clicking the corresponding `tasklist` button
    * this fixes an issue where restoring a client via mouse click on the `tasklist` button while the `navigator` is displayed will not include the restored client within the `navigator`
* submenus of `tasklist` menu and `clientmenu` will now update their position along with the parent menu
    * this fixes the following bug:
        * right click a client's titlebar to call the `clientmenu` or its `tasklist` button to call the window menu
        * hover the "Add to tag" entry, the submenu opens
        * quickly right-click another client's titlebar (or `tasklist` button respectively) while the former submenu is still open
        * the submenu of "Add to tag" will not update its position and is displayed where the menu of the previous client was
    * also includes a code optimization, aggregating two `ipairs` loops into one
* a `taglist`'s tag indicator will not show it's "occupied" state (e.g. filled inner circle) now when it only contains clients with the `skip_taskbar` property
* the client buttons in the `tasklist` are now sorted by their corresponding client's class
    * enables deterministic order of client buttons instead of an arbitrary one
    * this fixes an issue where the order of buttons sometimes changes when a client goes from grouped task button (# of clients > 1) to single task button (# of clients == 1)
