### PR TITLE
ellipsize support for tasktips

### DIFF
--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -339,6 +339,14 @@ local function tasktip_line(style)
 	-- tasktip line metods
 	function line:set_text(text)
 		line.tb:set_markup(text)
+
+		if style.max_width then
+			line.tb:set_ellipsize("middle")
+			_, line_h = line.tb:get_preferred_size()
+			line.tb:set_forced_height(line_h)
+			line.tb:set_forced_width(style.max_width)
+		end
+
 		line.field:set_fg(style.color.text)
 		line.field:set_bg(style.color.wibox)
 	end
@@ -434,6 +442,9 @@ local function construct_tasktip(c_group, layout, data, buttons, style)
 
 		line:set_text(awful.util.escape(c.name) or "Untitled")
 		tb_w, tb_h = line.tb:get_preferred_size()
+		if line.tb.forced_width then
+			tb_w = math.min(line.tb.forced_width, tb_w)
+		end
 
 		-- set state highlight only for grouped tasks
 		if #c_group > 1 or style.sl_highlight then


### PR DESCRIPTION
This adds support for shortening (ellipsize) the labels of the tasklist tooltips (tasktip). This prevents long window titles from spanning the entire screen in the tooltip.

- only applied to oversized tooltips, smaller tooltips are not enlarged
- only applies if `theme.widget.tasklist.tasktip.max_width` is set via `beautiful`

#### Before

![tasktip-vanilla](https://user-images.githubusercontent.com/1408105/49471216-a49f4f00-f80c-11e8-8a64-f662b7bf6da0.png)

#### After (using  `theme.widget.tasklist.tasktip.max_width = 500`)

![tasktip-ellipsized](https://user-images.githubusercontent.com/1408105/49471223-a6691280-f80c-11e8-8990-f055dbc998c4.png)
