### PR TITLE
fix tasklist for clients without class

### DIFF
--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -124,7 +124,7 @@ local function get_state(c_group, style)
 		table.insert(state.list, { focus = client.focus == c, urgent = c.urgent, minimized = c.minimized })
 	end
 
-	local class = c_group[1].class or "Untitled"
+	local class = c_group[1].class or "Undefined"
 	state.text = names[class] or string.upper(string.sub(class, 1, chars))
 	state.num = #c_group
 	state.icon = style.custom_icon and style.icons[style.iconnames[class] or string.lower(class)]
@@ -292,11 +292,11 @@ local function group_task(clients, need_group)
 
 	for _, c in ipairs(clients) do
 		if need_group then
-			local index = awful.util.table.hasitem(classes, c.class)
+			local index = awful.util.table.hasitem(classes, c.class or "Undefined")
 			if index then
 				table.insert(client_groups[index], c)
 			else
-				table.insert(classes, c.class)
+				table.insert(classes, c.class or "Undefined")
 				table.insert(client_groups, { c })
 			end
 		else
@@ -379,7 +379,7 @@ local function switch_focus(list, is_reverse)
 end
 
 local function client_group_sort_by_class(a, b)
-	return a[1].class < b[1].class
+	return (a[1].class or "Undefined") < (b[1].class or "Undefined")
 end
 
 -- Build or update tasklist.
@@ -566,7 +566,7 @@ function redtasklist.winmenu:init(style)
 	--------------------------------------------------------------------------------
 	function self:update(c)
 		if self.menu.wibox.visible then
-			classbox:set_text(c.class or "Unknown")
+			classbox:set_text(c.class or "Undefined")
 			stateboxes_update(c, state_icons, stateboxes)
 			tagmenu_update(c, self.menu, { 1, 2 }, style)
 		end


### PR DESCRIPTION
This fixes an issue with tasklist handling for windows/clients that don't set any class.

#### Steps to reproduce

1. install MusicBrainz Picard
2. open up MusicBrainz Picard

You can use `xprop` on the Picard window, it will not show any `WM_CLASS` (as per MusicBrainz Picard 1.3.2 on Debian 9.6)

#### Actual result

- window of MusicBrainz Picard does not show up in the tasklist
- sometimes awesome will throw an error popup when starting or interacting with Picard
- sometimes unrelated tasklist buttons will trigger the Picard window

#### Expected result

- window of MusicBrainz Picard should show up in the tasklist as a dedicated button and be controlled only via that button