### PR TITLE
Add custom shape support to all float widgets and tooltips

### DIFF
--- a/float/apprunner.lua
+++ b/float/apprunner.lua
@@ -20,6 +20,7 @@ local dfparser = require("redflat.service.dfparser")
 local redutil = require("redflat.util")
 local decoration = require("redflat.float.decoration")
 local redtip = require("redflat.float.hotkeys")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables and vars for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -70,7 +71,8 @@ local function default_style()
 		keytip           = { geometry = { width = 400, height = 300 } },
 		dimage           = redutil.base.placeholder(),
 		color            = { border = "#575757", text = "#aaaaaa", highlight = "#eeeeee", main = "#b1222b",
-		                     bg = "#161616", bg_second = "#181818", wibox = "#202020", icon = "a0a0a0" }
+		                     bg = "#161616", bg_second = "#181818", wibox = "#202020", icon = "a0a0a0" },
+		shape            = rectshape
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.apprunner") or {})
 end
@@ -300,7 +302,8 @@ function apprunner:init()
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 
 	self.wibox:set_widget(area_layout)

--- a/float/appswitcher.lua
+++ b/float/appswitcher.lua
@@ -32,6 +32,7 @@ local dfparser = require("redflat.service.dfparser")
 local redutil = require("redflat.util")
 local redtip = require("redflat.float.hotkeys")
 local redtitle = require("redflat.titlebar")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables and vars for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -95,7 +96,8 @@ local function default_style()
 		hotkeys         = { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" },
 		font            = { font = "Sans", size = 16, face = 0, slant = 0 },
 		color           = { border = "#575757", text = "#aaaaaa", main = "#b1222b", preview_bg = "#b1222b80",
-		                    wibox  = "#202020", icon = "#a0a0a0", bg   = "#161616", gray = "#575757" }
+		                    wibox  = "#202020", icon = "#a0a0a0", bg   = "#161616", gray = "#575757" },
+		shape           = rectshape
 	}
 
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.appswitcher") or {})
@@ -186,7 +188,8 @@ function appswitcher:init()
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 
 	-- Keygrabber

--- a/float/hotkeys.lua
+++ b/float/hotkeys.lua
@@ -15,6 +15,7 @@ local timer = require("gears.timer")
 
 local redflat = require("redflat")
 local redutil = require("redflat.util")
+local rectshape = require("gears.shape").rectangle
 
 
 -- Initialize tables for module
@@ -41,7 +42,8 @@ local function default_style()
 		is_align      = false,
 		separator     = {},
 		color         = { border = "#575757", text = "#aaaaaa", main = "#b1222b", wibox = "#202020",
-		                  gray = "#575757" }
+		                  gray = "#575757" },
+		shape         = rectshape
 	}
 
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.hotkeys") or {})
@@ -192,7 +194,8 @@ function hotkeys:init()
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 
 	self.wibox:geometry(style.geometry)

--- a/float/keychain.lua
+++ b/float/keychain.lua
@@ -16,6 +16,7 @@ local beautiful = require("beautiful")
 local redflat = require("redflat")
 local redutil = require("redflat.util")
 local redtip = require("redflat.float.hotkeys")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables and vars for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -35,7 +36,8 @@ local function default_style()
 		font            = "Sans 14 bold",
 		border_width    = 2,
 		keytip          = { geometry = { width = 500, height = 600 }, exit = false },
-		color           = { border = "#575757", wibox = "#202020" }
+		color           = { border = "#575757", wibox = "#202020" },
+		shape           = rectshape
 	}
 
 	return redflat.util.table.merge(style, redflat.util.table.check(beautiful, "float.keychain") or {})
@@ -105,7 +107,8 @@ function keychain:init(style)
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 	self.wibox:geometry(style.geometry)
 

--- a/float/notify.lua
+++ b/float/notify.lua
@@ -15,6 +15,7 @@ local timer = require("gears.timer")
 local redutil = require("redflat.util")
 local svgbox = require("redflat.gauge.svgbox")
 local progressbar = require("redflat.gauge.graph.bar")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -35,7 +36,8 @@ local function default_style()
 		timeout         = 5,
 		icon            = nil,
 		progressbar     = {},
-		color           = { border = "#575757", icon = "#aaaaaa", wibox = "#202020" }
+		color           = { border = "#575757", icon = "#aaaaaa", wibox = "#202020" },
+		shape           = rectshape
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.notify") or {})
 end
@@ -71,7 +73,8 @@ function notify:init()
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 
 	self.wibox:set_widget(wibox.container.margin(area, unpack(style.border_margin)))

--- a/float/player.lua
+++ b/float/player.lua
@@ -20,6 +20,7 @@ local redutil = require("redflat.util")
 local progressbar = require("redflat.gauge.graph.bar")
 local dashcontrol = require("redflat.gauge.graph.dash")
 local svgbox = require("redflat.gauge.svgbox")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize and vars for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -80,7 +81,8 @@ local function default_style()
 			prev_tr = redutil.base.placeholder({ txt = "←" }),
 		},
 		color          = { border = "#575757", main = "#b1222b",
-		                   wibox = "#202020", gray = "#575757", icon = "#a0a0a0" }
+		                   wibox = "#202020", gray = "#575757", icon = "#a0a0a0" },
+		shape          = rectshape
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.player") or {})
 end
@@ -223,7 +225,8 @@ function player:init(args)
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 
 	self.wibox:set_widget(wibox.container.margin(area, unpack(style.border_gap)))

--- a/float/prompt.lua
+++ b/float/prompt.lua
@@ -19,6 +19,7 @@ local wibox = require("wibox")
 
 local redutil = require("redflat.util")
 local decoration = require("redflat.float.decoration")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -31,7 +32,8 @@ local function default_style()
 		geometry     = { width = 620, height = 120 },
 		margin       = { 20, 20, 40, 40 },
 		border_width = 2,
-		color        = { border = "#575757", wibox = "#202020" }
+		color        = { border = "#575757", wibox = "#202020" },
+		shape        = rectshape
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.prompt") or {})
 end
@@ -58,7 +60,8 @@ function floatprompt:init(args)
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 
 	self.wibox:set_widget(wibox.container.margin(self.decorated_widget, unpack(style.margin)))

--- a/float/qlaunch.lua
+++ b/float/qlaunch.lua
@@ -21,6 +21,7 @@ local color = require("gears.color")
 local redflat = require("redflat")
 local redutil = require("redflat.util")
 local redtip = require("redflat.float.hotkeys")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables and vars for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -90,7 +91,8 @@ local function default_style()
 		border_width    = 2,
 		keytip          = { geometry = { width = 500, height = 400 }, exit = false },
 		color           = { border = "#575757", text = "#aaaaaa", main = "#b1222b", urgent = "#32882d",
-		                    wibox  = "#202020", icon = "#a0a0a0", bg   = "#161616", gray   = "#575757" }
+		                    wibox  = "#202020", icon = "#a0a0a0", bg   = "#161616", gray   = "#575757" },
+		shape           = rectshape
 	}
 
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.qlaunch") or {})
@@ -337,7 +339,8 @@ function qlaunch:init(args, style)
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 	self.wibox:geometry(style.geometry)
 	redutil.placement.centered(self.wibox, nil, screen[mouse.screen].workarea)

--- a/float/tooltip.lua
+++ b/float/tooltip.lua
@@ -21,6 +21,7 @@ local beautiful = require("beautiful")
 local timer = require("gears.timer")
 
 local redutil = require("redflat.util")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -34,7 +35,8 @@ local function default_style()
 		timeout      = 1,
 		font  = "Sans 12",
 		border_width = 2,
-		color        = { border = "#404040", text = "#aaaaaa", wibox = "#202020" }
+		color        = { border = "#404040", text = "#aaaaaa", wibox = "#202020" },
+		shape        = rectshape
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.tooltip") or {})
 end
@@ -62,6 +64,7 @@ function tooltip.new(args, style)
 	ttp.wibox.ontop = true
 	ttp.wibox.border_width = style.border_width
 	ttp.wibox.border_color = style.color.border
+	ttp.wibox.shape = style.shape
 	ttp.wibox:set_bg(style.color.wibox)
 	ttp.wibox:set_fg(style.color.text)
 

--- a/float/top.lua
+++ b/float/top.lua
@@ -15,6 +15,7 @@ local redutil = require("redflat.util")
 local system = require("redflat.system")
 local decoration = require("redflat.float.decoration")
 local redtip = require("redflat.float.hotkeys")
+local rectshape = require("gears.shape").rectangle
 
 
 -- Initialize tables for module
@@ -75,7 +76,8 @@ local function default_style()
 		title_font    = "Sans 14 bold",
 		unit          = { { "KB", -1 }, { "MB", 1024 }, { "GB", 1024^2 } },
 		color         = { border = "#575757", text = "#aaaaaa", highlight = "#eeeeee", main = "#b1222b",
-		                  bg = "#161616", bg_second = "#181818", wibox = "#202020" }
+		                  bg = "#161616", bg_second = "#181818", wibox = "#202020" },
+		shape         = rectshape
 
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "float.top") or {})
@@ -303,7 +305,8 @@ function top:init()
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 
 	self.wibox:set_widget(list_layout)

--- a/menu.lua
+++ b/menu.lua
@@ -36,6 +36,7 @@ local type = type
 local redutil = require("redflat.util")
 local svgbox = require("redflat.gauge.svgbox")
 local redtip = require("redflat.float.hotkeys")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -64,7 +65,8 @@ local function default_theme()
 		keytip       = { geometry = { width = 400, height = 400 } },
 		color        = { border = "#575757", text = "#aaaaaa", highlight = "#eeeeee",
 		                 main = "#b1222b", wibox = "#202020",
-		                 submenu_icon = nil, right_icon = nil, left_icon = nil }
+		                 submenu_icon = nil, right_icon = nil, left_icon = nil },
+		shape        = rectshape
 	}
 	return redutil.table.merge(style, beautiful.menu or {})
 end
@@ -631,7 +633,8 @@ function menu.new(args, parent)
 		fg    = _menu.theme.color.text,
 		bg    = _menu.theme.color.wibox,
 		border_color = _menu.theme.color.border,
-		border_width = _menu.theme.border_width
+		border_width = _menu.theme.border_width,
+		shape = _menu.theme.shape
 	})
 
 	_menu.wibox.visible = false

--- a/service/navigator.lua
+++ b/service/navigator.lua
@@ -18,6 +18,7 @@ local redflat = require("redflat")
 local redutil = require("redflat.util")
 local redtip = require("redflat.float.hotkeys")
 local rednotify = require("redflat.float.notify")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables and vars for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -43,7 +44,8 @@ local function default_style()
 		font         = { font = "Sans", size = 22, face = 1, slant = 0 },
 		color        = { border = "#575757", wibox = "#00000000", bg1 = "#57575740", bg2 = "#57575720",
 		                 fbg1 = "#b1222b40", fbg2 = "#b1222b20", mark = "#575757", text = "#202020",
-		                 hbg1 = "#32882d40", hbg2 = "#32882d20" }
+		                 hbg1 = "#32882d40", hbg2 = "#32882d20" },
+		shape        = rectshape
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "service.navigator") or {})
 end
@@ -163,7 +165,8 @@ function navigator.make_decor(c)
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.borderk
+		border_color = style.color.borderk,
+		shape        = style.shape
 	})
 
 	object.client = c

--- a/widget/minitray.lua
+++ b/widget/minitray.lua
@@ -23,6 +23,7 @@ local timer = require("gears.timer")
 local redutil = require("redflat.util")
 local dotcount = require("redflat.gauge.graph.dots")
 local tooltip = require("redflat.float.tooltip")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables and wibox
 -----------------------------------------------------------------------------------------------------------------------
@@ -39,7 +40,8 @@ local function default_style()
 		border_width = 2,
 		double_wibox = false,
 		show_delay   = 0.05,
-		color        = { wibox = "#202020", border = "#575757" }
+		color        = { wibox = "#202020", border = "#575757" },
+		shape        = rectshape
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "widget.minitray") or {})
 end
@@ -54,7 +56,8 @@ function minitray:init(style)
 		ontop        = true,
 		bg           = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	}
 
 	self.wibox = wibox(wargs)

--- a/widget/tasklist.lua
+++ b/widget/tasklist.lua
@@ -32,6 +32,7 @@ local separator = require("redflat.gauge.separator")
 local redmenu = require("redflat.menu")
 local svgbox = require("redflat.gauge.svgbox")
 local dfparser = require("redflat.service.dfparser")
+local rectshape = require("gears.shape").rectangle
 
 -- Initialize tables and vars for module
 -----------------------------------------------------------------------------------------------------------------------
@@ -90,7 +91,8 @@ local function default_style()
 		timeout      = 0.5,
 		sl_highlight = false, -- single line highlight
 		color        = { border = "#575757", text = "#aaaaaa", main = "#b1222b", highlight = "#eeeeee",
-		                 wibox = "#202020", gray = "#575757", urgent = "#32882d" }
+		                 wibox = "#202020", gray = "#575757", urgent = "#32882d" },
+		shape        = rectshape
 
 	}
 	style.winmenu.menu = {
@@ -631,7 +633,8 @@ function redtasklist.tasktip:init(buttons, style)
 		type = "tooltip",
 		bg   = style.color.wibox,
 		border_width = style.border_width,
-		border_color = style.color.border
+		border_color = style.color.border,
+		shape        = style.shape
 	})
 
 	self.wibox.ontop = true


### PR DESCRIPTION
This adds support for specifying a `gears.shape` for all redflat's widgets and tooltip popups.

Can be used (optionally) via `beautiful` like this:

```lua
theme.border_radius = 3

local widget_shape = function(cr, width, height)
    gears.shape.rounded_rect(cr, width, height, theme.border_radius)
end

theme.float.player = {
    ...
    shape        = widget_shape,
}

theme.float.prompt = {
    ...
    shape        = widget_shape,
}
...
```

I use it in my configs to get rounded corners on everything. Feel free to reject if you don't find this useful.