### PR TITLE
feat: general imap log in mechanism will work with exchange

### DIFF
--- a/widget/mail.lua
+++ b/widget/mail.lua
@@ -57,18 +57,19 @@ mail.check_function["curl_imap"] = function(args)
 	return curl_req
 end
 
-mail.check_function["exchange"] = function(args)
+mail.check_function["imap"] = function(args)
 	-- require imap4 library
 	-- need to luarock install imap4 library
 	local imap4   = require "imap4"
 
 	-- grab args or set default values
+	-- gmail requires 'Less secure app access'
 	local port = args.port or 993
 	local url = args.server or "outlook.office365.com"
 	local mailbox = args.mailbox or "Inbox"
 
 	-- setup connection
-	local connection = imap4(url, port, {protocol = 'sslv23'})
+	local connection = imap4(url, port, {protocol = 'tlsv1_2'})
 	assert(connection:isCapable('IMAP4rev1'))
 	connection:login(args.username, args.password)
 


### PR DESCRIPTION
As you suggest I changed the exchange to a general imap checker. Works with both gmail and microsoft exchange server. I have unittested them both. I am working on implementing a pop3 checker as well. In fact, I wrote a Mailer class using 30log rock that you may be interested in rather than what you have done in your mail.lua [https://gist.github.com/jessequinn/98eef93ee58be3dec193fb75561a35d8](url).