### PR TITLE
orange tag support text inside circle

### DIFF
--- a/gauge/tag/orange.lua
+++ b/gauge/tag/orange.lua
@@ -31,6 +31,8 @@ local function default_style()
 		cgap         = TPI / 20,
 		show_min     = true,
 		min_sections = 1,
+		text         = false,
+		font         = { font = "Sans", size = 16, face = 0, slant = 0 },
 		color        = { main  = "#b1222b", gray  = "#575757", icon = "#a0a0a0", urgent = "#32882d" }
 	}
 
@@ -48,6 +50,7 @@ function orangetag.new(style)
 
 	-- updating values
 	local data = {
+		state = { text = "TEXT" },
 		width = style.width or nil
 	}
 
@@ -89,8 +92,18 @@ function orangetag.new(style)
 		cl = data.state.active and style.color.main or (data.state.occupied and  style.color.icon or style.color.gray)
 		cr:set_source(color(cl))
 
-		cr:arc(width / 2, height / 2, style.iradius, 0, TPI)
-		cr:fill()
+		if style.text then
+			-- text
+			redutil.cairo.set_font(cr, style.font)
+			local ext = cr:text_extents(tostring(#data.state.list))
+			cr:move_to((width - ext.width - ext.x_bearing) / 2, (height + ext.height + ext.x_bearing) / 2)
+			cr:show_text(data.state.text)
+			cr:stroke()
+		else
+			-- round
+			cr:arc(width / 2, height / 2, style.iradius, 0, TPI)
+			cr:fill()
+		end
 
 		-- occupied mark
 		cr:set_line_width(style.line_width)


### PR DESCRIPTION
Related to https://github.com/worron/awesome-config/issues/38

`theme.lua`

```lua
    -- Tag (base element of taglist)                                                            
    ------------------------------------------------------------                                
    self.gauge.tag.orange = {                                                                   
        width        = self.gauge.monitor.circle.width,      -- widget width
        line_width   = self.gauge.monitor.circle.line_width, -- width of arcs
        iradius      = self.gauge.monitor.circle.iradius,    -- radius for center point
        radius       = self.gauge.monitor.circle.radius,     -- arcs radius
        cgap         = 0.314,                                -- gap between arcs in radians
        min_sections = 1,                                    -- minimal amount of arcs
        show_min     = false,                                -- indicate minimized apps by color
        text         = true,                                 -- replace middle circle by text
        font         = self.cairo_fonts.tag,                 -- font for text
        color        = self.color                            -- colors (main used)
    }
```
`rc-theme.lua`
```lua
-- tags
awful.tag({ "", "", "", "", "", "", "", "", "" }, s, awful.layout.layouts[1])
```

Use a font that support icons glyphs, ex [NerdFonts](https://nerdfonts.com)

![](https://i.imgur.com/JRkXGhW.png)