### PR TITLE
Accept underscore as part of Exec param in *.desktop files

### DIFF
--- a/service/dfparser.lua
+++ b/service/dfparser.lua
@@ -374,8 +374,8 @@ function dfparser.icon_list(style)
 
 		for _, prog in ipairs(programs) do
 			if prog.Icon and prog.Exec then
-				local key = string.match(prog.Exec, "[%a%d%.%-/]+")
-				if string.find(key, "/") then key = string.match(key, "[%a%d%.%-]+$") end
+				local key = string.match(prog.Exec, "[%a%d%.%-_/]+")
+				if string.find(key, "/") then key = string.match(key, "[%a%d%.%-_]+$") end
 				list[key] = prog.icon_path
 			end
 		end


### PR DESCRIPTION
Some programs (_e.g._ Sublime) may use underscore in its class name. This PR makes dfparser accept underscore as part of Exec param in *.desktop files, which are used when adding icons to `Qlaunch` for instance.
 * Fix worron/awesome-config#42