### PR TITLE
Add workaround for awesomeWM/awesome#2985 to player widget

### DIFF
--- a/float/player.lua
+++ b/float/player.lua
@@ -43,6 +43,21 @@ local dbus_set = dbus_mpris
 local dbus_action = dbus_mpris
                     .. "org.mpris.MediaPlayer2.Player."
 
+-- Hotfix for https://github.com/awesomeWM/awesome/issues/2985
+-----------------------------------------------------------------------------------------------------------------------
+local function mouse_get_current_widget_geometry()
+	local w = mouse.current_wibox
+	if w then
+		local geo, coords = w:geometry(), mouse:coords()
+		local bw = w.border_width
+
+		local list = w:find_widgets(coords.x - geo.x - bw, coords.y - geo.y - bw)
+
+		-- return the geometry of the topmost widget
+		return list[#list]
+	end
+end
+
 -- Helper function to decode URI string format
 -----------------------------------------------------------------------------------------------------------------------
 local function decodeURI(s)
@@ -197,7 +212,7 @@ function player:init(args)
 		awful.button(
 			{}, 1, function()
 				local coords = {
-					bar   = mouse.current_widget_geometry,
+					bar   = mouse_get_current_widget_geometry(),
 					wibox = mouse.current_wibox:geometry(),
 					mouse = mouse.coords(),
 				}


### PR DESCRIPTION
Up until recently, awesome was calculating `mouse.current_widget_geometry` incorrectly when borders are involved. See https://github.com/awesomeWM/awesome/issues/2985

Since `mouse.current_widget_geometry` is used in the `player` widget to determine the click position on the progress bar, this leads to wrong track positions being sent to the audio player depending at the click's Y coordinate relative to the progress bar (see the issue linked above for detailed illustration), if `border_width > 0` is set for the player widget.

The patch introduces an alternative to `mouse.current_widget_geometry` that correctly accounts for borders.
The issue has been fixed on awesome's master branch but this fixes it for people using older awesome 4.x versions.