### PR TITLE
Fix erronous activation of navigator on floating layouts in multi-monitor setups

### DIFF
--- a/service/navigator.lua
+++ b/service/navigator.lua
@@ -275,7 +275,7 @@ function navigator:run()
 	end
 
 	-- check handler
-	local l = awful.layout.get(client.focus.screen)
+	local l = awful.layout.get(s)
 	local handler = l.key_handler or redflat.layout.common.handler[l]
 	if not handler then
 		rednotify:show(redutil.table.merge({ text = "Layout not supported" }, self.style.notify))


### PR DESCRIPTION
With the `navigator` widget's current implementation the following issue can occur on multi-monitor setups:

- focused client is on a monitor with tiling layout
- mouse is on a monitor with floating layout
- `navigator:run()` is called
- navigator is displayed for clients on the monitor with the floating layout

... because the layout check is done against the focused client whereas the rest of the navigator references to the mouse position.

This patch fixes this error by referencing the mouse's screen for the layout check as well and will display an "Layout not supported" popup in the scenario described above instead of actually entering the navigator on the floating layout monitor.