### PR TITLE
Make menu fully consume click events to prevent leaking them below

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -469,7 +469,7 @@ function menu:add(args)
 
 	item._background:buttons(awful.util.table.join(
 		awful.button({}, 3, function () self:hide() end),
-		awful.button({}, 1, function ()
+		awful.button({}, 1, nil, function ()
 			self:item_enter(num)
 			self:exec(num)
 		end)

--- a/menu.lua
+++ b/menu.lua
@@ -467,12 +467,19 @@ function menu:add(args)
 	------------------------------------------------------------
 	local num = #self.items
 
+	local press_action = function()
+		self:item_enter(num)
+		self:exec(num)
+	end
+	local release_action
+
+	if theme.action_on_release then
+		release_action, press_action = press_action, release_action
+	end
+
 	item._background:buttons(awful.util.table.join(
 		awful.button({}, 3, function () self:hide() end),
-		awful.button({}, 1, nil, function ()
-			self:item_enter(num)
-			self:exec(num)
-		end)
+		awful.button({}, 1, press_action, release_action)
 	))
 
 	item.widget:connect_signal("mouse::enter", function() self:item_enter(num, { hover = true }) end)


### PR DESCRIPTION
This tiny adjustment fixed a rare error in my configuration where I draw custom titlebars with window controls on it.

There was an issue when I opened the root menu and it was overlapping the window titlebar buttons of a window in a way that when I clicked a menu entry, the click would coincidentally be at a position of one of the window controls. In such cases, the button of the window control always triggered (such as minimizing or closing the window), when I clicked a menu item.

This was because the `awful.button()` assignment of `menu.lua` only catches the button press event but not the button release event, which in some cases may still be propagated to elements below. This patch changes the menu to react to the release event and fully consume the click instead to prevent this.

YMMV as this might not directly affect any of your configs so feel free to handle this PR at your own discretion.