### PR TITLE
Fix pulse audio default sink

### DIFF
--- a/widget/pulse.lua
+++ b/widget/pulse.lua
@@ -64,8 +64,8 @@ end
 -- Change volume level
 -----------------------------------------------------------------------------------------------------------------------
 function pulse:change_volume(args)
-
 	-- initialize vars
+	self._sink = get_default_sink({ type = self._type })
 	args = redutil.table.merge(change_volume_default_args, args or {})
 	local diff = args.down and -args.step or args.step
 
@@ -109,6 +109,7 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 function pulse:mute(args)
 	args = args or {}
+	self._sink = get_default_sink({ type = self._type })
 	if not self._type or not self._sink then return end
 
 	local mute = redutil.read.output(string.format("pacmd dump | grep 'set-%s-mute %s'", self._type, self._sink))

--- a/widget/pulse.lua
+++ b/widget/pulse.lua
@@ -65,7 +65,9 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 function pulse:change_volume(args)
 	-- initialize vars
-	self._sink = get_default_sink({ type = self._type })
+	if args.sink_update then
+		self._sink = get_default_sink({ type = self._type })
+	end
 	args = redutil.table.merge(change_volume_default_args, args or {})
 	local diff = args.down and -args.step or args.step
 
@@ -109,7 +111,9 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 function pulse:mute(args)
 	args = args or {}
-	self._sink = get_default_sink({ type = self._type })
+	if args.sink_update then
+		self._sink = get_default_sink({ type = self._type })
+	end
 	if not self._type or not self._sink then return end
 
 	local mute = redutil.read.output(string.format("pacmd dump | grep 'set-%s-mute %s'", self._type, self._sink))

--- a/widget/pulse.lua
+++ b/widget/pulse.lua
@@ -64,10 +64,8 @@ end
 -- Change volume level
 -----------------------------------------------------------------------------------------------------------------------
 function pulse:change_volume(args)
+
 	-- initialize vars
-	if args.sink_update then
-		self._sink = get_default_sink({ type = self._type })
-	end
 	args = redutil.table.merge(change_volume_default_args, args or {})
 	local diff = args.down and -args.step or args.step
 
@@ -111,9 +109,6 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 function pulse:mute(args)
 	args = args or {}
-	if args.sink_update then
-		self._sink = get_default_sink({ type = self._type })
-	end
 	if not self._type or not self._sink then return end
 
 	local mute = redutil.read.output(string.format("pacmd dump | grep 'set-%s-mute %s'", self._type, self._sink))
@@ -131,6 +126,9 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 function pulse:update_volume(args)
 	args = args or {}
+	if args.sink_update then
+		self._sink = get_default_sink({ type = self._type })
+	end
 	if not self._type or not self._sink then return end
 
 	-- initialize vars


### PR DESCRIPTION
Fixes #59 

The logic in `get_default_sink` is correct. However, `self._sink` does not get updated whenever the default sink is changed. This is the solution i am proposing, which is checking for and setting the default sink for every `change_volume/mute` call.