### PR TITLE
Add missing redraw for icon gauges

### DIFF
--- a/gauge/icon/single.lua
+++ b/gauge/icon/single.lua
@@ -63,13 +63,13 @@ function gicon.new(style)
 
 	-- User functions
 	------------------------------------------------------------
-	function widg:set_value(x)
+	function widg:set_value(x, force_redraw)
 		if x > 1 then x = 1 end
 
 		if self.widget._image then
 			local level = math.floor(x / style.step) * style.step
 
-			if level ~= self._data.level then
+			if force_redraw or level ~= self._data.level then
 				self._data.level = level
 				local d = style.is_vertical and self.widget._image.height or self._image.width
 				self.widget:set_color(pattern(d, level, self._data.color, style.color.icon))
@@ -78,8 +78,12 @@ function gicon.new(style)
 	end
 
 	function widg:set_alert(alert)
-		-- not sure about redraw after alert set
+		local old_color = self._data.color
 		self._data.color = alert and style.color.urgent or style.color.main
+		if self._data.color ~= old_color then
+			-- force redraw if color has changed
+			self:set_value(self._data.level, true)
+		end
 	end
 
 	--------------------------------------------------------------------------------


### PR DESCRIPTION
I use a gauge icon for battery meter on a machine of mine. I had a problem where the alert state (when the battery charge reached critical levels) would only show up delayed on the icon. Vice versa, returning to non-alert state was also delayed by several minutes.

Turns out, when `step` is too coarse-grained then the gauge `level` might not change compared to the previous update cycle albeit the actual value has. So when `set_alert` is called, it might take the gauge multiple update cycles until the next `step` is reached and the new color is shown.

This PR adds a forced redraw to `set_alert` in case the color has changed.