### PR TITLE
Add margin to menu and fix transparency

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -54,6 +54,7 @@ local function default_theme()
 		height       = 20,
 		width        = 200,
 		font         = "Sans 12",
+		margin       = { 0, 0, 0, 0},  -- whole menu margin
 		icon_margin  = { 0, 0, 0, 0 }, -- left icon margin
 		ricon_margin = { 0, 0, 0, 0 }, -- right icon margin
 		nohide       = false,
@@ -294,7 +295,7 @@ function menu:item_leave(num)
 
 	if item then
 		item._background:set_fg(item.theme.color.text)
-		item._background:set_bg(item.theme.color.wibox)
+		item._background:set_bg("transparent")
 		if item.icon and item.theme.color.left_icon then item.icon:set_color(item.theme.color.left_icon) end
 		if item.right_icon then
 			if item.child and item.theme.color.submenu_icon then
@@ -456,7 +457,7 @@ function menu:add(args)
 	item.theme = item.theme or theme
 	item._background = wibox.container.background(item.widget)
 	item._background:set_fg(item.theme.color.text)
-	item._background:set_bg(item.theme.color.wibox)
+	item._background:set_bg("transparent")
 
 	-- Add item widget to menu layout
 	------------------------------------------------------------
@@ -644,11 +645,13 @@ function menu.new(args, parent)
 	})
 
 	_menu.wibox.visible = false
-	_menu.wibox:set_widget(_menu.layout)
+	_menu.wibox:set_widget(wibox.container.margin(_menu.layout, unpack(_menu.theme.margin)))
 
 	-- set size
 	_menu.wibox.width = _menu.theme.width
-	_menu.wibox.height = _menu.add_size > 0 and _menu.add_size or 1
+	-- we need to account for top and bottom margins so that the last element doesn't get squished
+	local total_height = _menu.add_size + _menu.theme.margin[3] + _menu.theme.margin[4]
+	_menu.wibox.height = total_height > 0 and total_height or 1
 
 	-- Set menu autohide timer
 	------------------------------------------------------------


### PR DESCRIPTION
These adjustments to `menu.lua` do two things:

- add optional margins around menus (default to none)
- set the background color of menu entries to "transparent"

This addresses the following issues:
- the menu border is often rendered after the widget, shifting the widget's coordinates slightly after being displayed, making it flicker/jump a bit sometimes (at least with compton/picom)
    - this effect increases the thicker the border is
    - using genuine margins instead of a thick border mitigates this effect
- even if the same color is chosen for both border and menu background, using transparency and especially blur with compton/picom will result in different shades of color (seems like borders are handled differently during alpha compositing?)
    - again, using margins instead of borders fixes this
- menu entries having their own background color (same as menu wibox) is superfluous but hurts transparency/blur setups due to the entries' background colors being stacked ontop of the menu background

This should not break the look/behavior of existing setups as the introduced margin defaults to 0 at all sides, which mimics the current implementation.