### PR TITLE
Fix cover image resize and alignment for player widget

### DIFF
--- a/float/player.lua
+++ b/float/player.lua
@@ -190,7 +190,9 @@ function player:init(args)
 	align_vertical:set_middle(wibox.container.margin(control_align, unpack(style.controls_margin)))
 	align_vertical:set_bottom(wibox.container.constraint(self.bar, "exact", nil, style.bar_width))
 	local area = wibox.layout.fixed.horizontal()
-	area:add(self.box.image)
+	local cover_area = wibox.container.place(self.box.image)
+	cover_area.forced_width = style.geometry.height - style.border_margin[3] - style.border_margin[4]
+	area:add(cover_area)
 	area:add(wibox.container.margin(align_vertical, unpack(style.elements_margin)))
 
 	-- Buttons
@@ -270,6 +272,7 @@ function player:init(args)
 	self.clear_info = function(is_att)
 		self.box.image:set_image(style.icon.cover)
 		self.box.image:set_color(is_att and style.color.main or style.color.gray)
+		self.box.image:emit_signal("widget::layout_changed")
 
 		self.box.time:set_text("0:00")
 		self.bar:set_value(0)
@@ -441,12 +444,14 @@ function player:update_from_metadata(data)
 			if image then
 				self.box.image:set_color(nil)
 				has_cover = self.box.image:set_image(decodeURI(image))
+				self.box.image:emit_signal("widget::layout_changed")
 			end
 		end
 		if not has_cover then
 			-- reset to generic icon if no cover available
 			self.box.image:set_color(self.style.color.gray)
 			self.box.image:set_image(self.style.icon.cover)
+			self.box.image:emit_signal("widget::layout_changed")
 		end
 
 		-- track length


### PR DESCRIPTION
The following behavior of the player widget currently happens with Audacious and albums that have cover images which are not square but are either wider than tall or vice versa (also see sketch below):

- at first, the area for the cover image is initialized as a square space
- when a cover is loaded that is not square-shaped, it is fit into the square space resized and aligned at the top (wide image) or left (tall image)
- after a delay of several secondes (or minutes?), the space for the cover image gets resized to fit the new cover aspect ratio and the whole controls area on the right either squished to the right (wide image) or expanded to the left (tall image)
- when a cover with a different aspect ratio is loaded, this process repeats (first cover is resized and later the whole controls area)

In this patch I fixed the resize delay by adding `self.box.image:emit_signal("widget::layout_changed")` to appropriate places and removed the cover resize behavior by forcing the cover area's width to be the same as the available height, thus restricting it to a square format and wrapped the image into a `wibox.container.place` to automatically center it.

#### Illustration of current and adjusted behavior

![redflat-player-coverfix](https://user-images.githubusercontent.com/1408105/96372894-6ba2c600-1169-11eb-8de2-8d620651c50d.png)
