### PR TITLE
Small fixes and enhancements

### DIFF
--- a/float/tooltip.lua
+++ b/float/tooltip.lua
@@ -30,6 +30,7 @@ local tooltip = { mt = {} }
 local function default_style()
 	local style = {
 		padding      = { vertical = 3, horizontal = 5 },
+		margin       = 0,
 		timeout      = 1,
 		font  = "Sans 12",
 		border_width = 2,
@@ -96,7 +97,7 @@ function tooltip.new(args, style)
 			else
 				awful.placement.under_mouse(ttp.wibox)
 			end
-			awful.placement.no_offscreen(ttp.wibox)
+			awful.placement.no_offscreen(ttp.wibox, { margins = style.margin })
 			ttp.wibox.visible = true
 			show_timer:stop()
 		end)
@@ -120,7 +121,7 @@ function tooltip.new(args, style)
 			if self.wibox.visible then
 				self:set_geometry()
 				self.wibox.x = mouse.coords().x - self.wibox.width / 2
-				awful.placement.no_offscreen(self.wibox)
+				awful.placement.no_offscreen(self.wibox, { margins = style.margin })
 			end
 		end
 	end

--- a/float/top.lua
+++ b/float/top.lua
@@ -243,7 +243,7 @@ function top:init()
 	-- Build title
 	--------------------------------------------------------------------------------
 	title = construct_item(style)
-	title:set_bg(style.color.wibox)
+	title:set_bg("transparent")
 	title:set({ number = "#", name = "Process Name", cpu = "▾ CPU", mem = "Memory"})
 
 	for _, txtbox in pairs(title.label) do

--- a/widget/minitray.lua
+++ b/widget/minitray.lua
@@ -101,6 +101,7 @@ function minitray:update_geometry()
 	end
 
 	redutil.placement.no_offscreen(self.wibox, self.screen_gap, mouse.screen.workarea)
+	self.tray.screen = self.wibox.screen
 end
 
 -- Show


### PR DESCRIPTION
This small patchset contains the following adjustments:

#### `float/top.lua`

- removes superfluous background color of the title header which causes background stacking issues for transparency-enabled themes, similar to #65

#### `float/tooltip.lua`

- introduces a `margin` theming option that allows adding a gap between the wibar and displayed tooltips

#### `widget/minitray.lua`

- fixes a bug where the systray would be blank/empty when opened on a secondary screen after the screen arrangement has changed in multi-monitor setups, which can be reproduced as follows:
    1. use multi-monitor setup
    2. start awesome with one screen active
    3. activate second screen (e.g. via `xrandr --output $SECONDARY --auto --right-of $PRIMARY`)
    4. awesome will restart (due to config)
    5. move mouse cursor to second screen and open the minitray
    6. minitray will be blank and display no icons until opened on the primary screen once