### PR TITLE
Add visual tag selector and screen switch option to client menus

### DIFF
--- a/float/clientmenu.lua
+++ b/float/clientmenu.lua
@@ -39,27 +39,34 @@ local last = {
 -----------------------------------------------------------------------------------------------------------------------
 local function default_style()
 	local style = {
-		icon            = { unknown = redutil.base.placeholder(),
-		                    minimize = redutil.base.placeholder(),
-		                    close = redutil.base.placeholder() },
-		micon           = { blank = redutil.base.placeholder({ txt = " " }),
-		                    check = redutil.base.placeholder({ txt = "+" }) },
-		layout_icon     = { unknown = redutil.base.placeholder() },
-		actionline      = { height = 28 },
-		stateline       = { height = 35 },
-		state_iconsize  = { width = 20, height = 20 },
-		action_iconsize = { width = 18, height = 18 },
-		separator       = { marginh = { 3, 3, 5, 5 }, marginv = { 3, 3, 3, 3 } },
-		tagmenu         = { icon_margin = { 2, 2, 2, 2 } },
-		hide_action     = { move = true,
-		                    add = false,
-		                    min = true,
-		                    floating = false,
-		                    sticky = false,
-		                    ontop = false,
-		                    below = false,
-		                    maximized = false },
-		color           = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040", highlight = "#eeeeee" },
+		icon                 = { unknown = redutil.base.placeholder(),
+		                         minimize = redutil.base.placeholder(),
+		                         close = redutil.base.placeholder(),
+		                         tag = redutil.base.placeholder({ txt = "■" }),
+		                         switch_screen = redutil.base.placeholder() },
+		micon                = { blank = redutil.base.placeholder({ txt = " " }),
+		                         check = redutil.base.placeholder({ txt = "+" }) },
+		layout_icon          = { unknown = redutil.base.placeholder() },
+		actionline           = { height = 28, center_button_width = 50 },
+		stateline            = { height = 35 },
+		tagline              = { height = 30 },
+		state_iconsize       = { width = 20, height = 20 },
+		action_iconsize      = { width = 18, height = 18 },
+		tag_iconsize         = { width = 16, height = 16 },
+		separator            = { marginh = { 3, 3, 5, 5 }, marginv = { 3, 3, 3, 3 } },
+		tagmenu              = { icon_margin = { 2, 2, 2, 2 } },
+		hide_action          = { move = true,
+		                         add = false,
+		                         min = true,
+		                         floating = false,
+		                         sticky = false,
+		                         ontop = false,
+		                         below = false,
+		                         maximized = false },
+		enable_screen_switch = false,
+		enable_tagline       = false,
+		tagline_mod_key      = "Mod4",
+		color                = { main = "#b1222b", icon = "#a0a0a0", gray = "#404040", highlight = "#eeeeee" },
 	}
 	style.menu = {
 		ricon_margin = { 2, 2, 2, 2 },
@@ -226,8 +233,29 @@ local function action_line_construct(setup_layout, style)
 	)
 	setup_layout:set_first(minimize_box)
 
-	-- separator
-	setup_layout:set_second(sep)
+	-- center element (either switch screen button or separator only)
+	if style.enable_screen_switch and screen.count() > 1 then
+		local inner = wibox.layout.align.horizontal()
+
+		-- switch screen button
+		local switch_screen_button = actionbox_construct(
+			style.icon.switch_screen,
+			function()
+				redutil.placement.next_screen(last.client)
+				clientmenu.menu:hide()
+			end
+		)
+		-- button surrounded by separators
+		inner:set_first(sep)
+		inner:set_second(switch_screen_button)
+		inner:set_third(sep)
+		inner:set_forced_width(style.actionline.center_button_width)
+
+		setup_layout:set_second(inner)
+	else
+		-- separator only
+		setup_layout:set_second(sep)
+	end
 
 	-- close button
 	local close_box = actionbox_construct(
@@ -238,6 +266,62 @@ local function action_line_construct(setup_layout, style)
 		end
 	)
 	setup_layout:set_third(close_box)
+end
+
+-- Function to construct menu line with tag switches (for style.enable_tagline)
+-----------------------------------------------------------------------------------
+local function tag_line_construct(setup_layout, style)
+	local tagboxes = {}
+
+	for i, t in ipairs(last.screen.tags) do
+		if not awful.tag.getproperty(t, "hide") then
+
+			tagboxes[i] = svgbox(style.icon.tag)
+			tagboxes[i]:set_forced_width(style.tag_iconsize.width)
+			tagboxes[i]:set_forced_height(style.tag_iconsize.height)
+
+			-- set widget in line
+			local l = wibox.layout.align.horizontal()
+			l:set_expand("outside")
+			l:set_second(tagboxes[i])
+			setup_layout:add(l)
+
+			-- set mouse action
+			tagboxes[i]:buttons(awful.util.table.join(
+				awful.button({}, 1,
+					function()
+						last.client:move_to_tag(t)
+						awful.layout.arrange(t.screen)
+						clientmenu.menu:hide()
+					end
+				),
+				awful.button({ style.tagline_mod_key }, 1,
+					function()
+						last.client:move_to_tag(t)
+						awful.layout.arrange(t.screen)
+						clientmenu.menu:hide()
+						t:view_only()
+					end
+				),
+				awful.button({}, 2,
+					function()
+						last.client:move_to_tag(t)
+						awful.layout.arrange(t.screen)
+						clientmenu.menu:hide()
+						t:view_only()
+					end
+				),
+				awful.button({}, 3,
+					function()
+						last.client:toggle_tag(t)
+						awful.layout.arrange(t.screen)
+					end
+				)
+			))
+		end
+	end
+
+	return tagboxes
 end
 
 -- Calculate menu position
@@ -321,23 +405,34 @@ function clientmenu:init(style)
 		last.client:toggle_tag(t); awful.layout.arrange(t.screen); self.hide_check("add")
 	end
 
-	-- Construct tag submenus ("move" and "add")
-	------------------------------------------------------------
-	local movemenu_items = tagmenu_items(self.movemenu_action, style)
-	local addmenu_items  = tagmenu_items(self.addmenu_action, style)
+	local menu_items = {}
+	table.insert(menu_items, { widget = actionline, focus = true })
+	table.insert(menu_items, menusep)
+	if style.enable_tagline then
+		-- Construct visual tag representations in a menu line
+		self.tagline_container = wibox.layout.flex.horizontal()
+		local tagline_vertical = wibox.layout.align.vertical()
+		tagline_vertical:set_second(self.tagline_container)
+		tagline_vertical:set_expand("outside")
+		self.tagboxes = tag_line_construct(self.tagline_container, style)
+		local tagline = wibox.container.constraint(tagline_vertical, "exact", nil, style.tagline.height)
+		table.insert(menu_items, { widget = tagline, focus = true })
+	else
+		-- Construct tag submenus ("move" and "add")
+		local movemenu_items = tagmenu_items(self.movemenu_action, style)
+		local addmenu_items  = tagmenu_items(self.addmenu_action, style)
+		table.insert(menu_items, { "Move to tag", { items = movemenu_items, theme = style.tagmenu } })
+		table.insert(menu_items, { "Add to tag",  { items = addmenu_items,  theme = style.tagmenu } })
+	end
+	table.insert(menu_items, menusep)
+	table.insert(menu_items, { widget = stateline, focus = true })
+
 
 	-- Create menu
 	------------------------------------------------------------
 	self.menu = redmenu({
 		theme = style.menu,
-		items = {
-			{ widget = actionline, focus = true },
-			menusep,
-			{ "Move to tag", { items = movemenu_items, theme = style.tagmenu } },
-			{ "Add to tag",  { items = addmenu_items,  theme = style.tagmenu } },
-			menusep,
-			{ widget = stateline, focus = true }
-		}
+		items = menu_items
 	})
 
 	-- Widget update functions
@@ -345,7 +440,11 @@ function clientmenu:init(style)
 	function self:update(c)
 		if self.menu.wibox.visible then
 			stateboxes_update(c, state_icons, stateboxes)
-			tagmenu_update(c, self.menu, { 1, 2 }, style)
+			if style.enable_tagline then
+				self:tagline_update(c, style)
+			else
+				tagmenu_update(c, self.menu, { 1, 2 }, style)
+			end
 		end
 	end
 
@@ -357,6 +456,34 @@ function clientmenu:init(style)
 	}
 	for _, sg in ipairs(client_signals) do
 		client.connect_signal(sg, function() self:update(last.client) end)
+	end
+end
+
+-- Function to rebuild the tag line entirely if screen and tags have changed
+--------------------------------------------------------------------------------
+function clientmenu:tagline_rebuild(style)
+	self.tagline_container:set_children({})
+	self.tagboxes = tag_line_construct(self.tagline_container, style)
+end
+
+-- Function to update the tag line's icon states
+--------------------------------------------------------------------------------
+function clientmenu:tagline_update(c, style)
+	if last.tag_screen ~= mouse.screen then
+		self:tagline_rebuild(style)
+		last.tag_screen = mouse.screen
+	end
+	for k, t in ipairs(last.screen.tags) do
+		if not awful.tag.getproperty(t, "hide") then
+
+			local icon_color = style.color.gray
+			if c then
+				local client_tags = c:tags()
+				icon_color = awful.util.table.hasitem(client_tags, t) and style.color.main or icon_color
+			end
+
+			self.tagboxes[k]:set_color(icon_color)
+		end
 	end
 end
 

--- a/util/placement.lua
+++ b/util/placement.lua
@@ -35,6 +35,17 @@ function placement.no_offscreen(object, gap, area)
 	object:geometry(geometry)
 end
 
+-- make window fit screen bounds
+local function control_off_screen(window, workarea)
+	local wa = workarea or screen[window.screen].workarea
+	local wg = window:geometry()
+
+	if wg.width > wa.width then window:geometry({ width = wa.width, x = wa.x }) end
+	if wg.height > wa.height then window:geometry({ height = wa.height, y = wa.y }) end
+
+	placement.no_offscreen(window, nil, wa)
+end
+
 local function centered_base(is_h, is_v)
 	return function(object, gap, area)
 		local geometry = object:geometry()
@@ -48,6 +59,19 @@ local function centered_base(is_h, is_v)
 		if is_v then new_geometry.y = area.y + (area.height - geometry.height) / 2 - object.border_width end
 
 		return object:geometry(new_geometry)
+	end
+end
+
+-- attempts to move the focused client to the next screen (if screen.count() > 1)
+-- if a specific client is not passed via 'c', the focused client is selected
+function placement.next_screen(c)
+	local c = c or client.focus
+	if not c then return end
+	local next_idx = c.screen.index + 1
+	local next_screen = screen[ next_idx > screen.count() and 1 or next_idx ]
+	if screen.count() > 1 then
+		c:move_to_screen(next_screen)
+		control_off_screen(c, next_screen.workarea)
 	end
 end
 


### PR DESCRIPTION
#### Preface

This is the last of the bigger PRs for now and should get reviewed after the others as it might need more discussion.  
It is not as universal as my previous redflat additions. I guess the adjustments have a tendency to be rather specific to my personal keyboard+mouse hybrid workflow. For that reason, I'm not entirely confident that they live up to the standards of redflat.

---

I have made some additions to client menus that allow easy single-click screen and tag switching for a client. The features apply to both `redflat.float.clientmenu` and `redflat.widget.tasklist` client menus. Both additions may be enabled/disabled independently and are disabled by default, not altering existing configs. They implement the following additions:

1. a visual replacement for the "Move to tag" / "Add to tag" menus
2. a new button / menu entry for moving the client to another screen

Taking the clientmenu as an example, this is how it works:

![vtag-sswitch-clientmenu-explanation](https://user-images.githubusercontent.com/1408105/96378004-82f1ab80-1189-11eb-978b-59c6c711bdf2.jpg)

### Part I: visual tag toggles (`tagline`)

When activated, instead of submenus for moving/adding clients to tags, there is a line with visual representations of the tags (e.g. dots or squares) of the corresponding screen. Highlighted icons represent tags which the client is tagged with. Clicking with different mouse buttons on the visual tag icons will trigger move or add/remove actions for the client for that tag, depending on the button (see picture above).
As a mouse user in menus, find this version both more intuitive (as in having the same visual horizontal tag enumeration as on my wibar) and a lot quicker to use (no nested submenus, simple single clicks only) but it depends on the workflow and configuration of the user.

This option does not play well with a large amount of tags though as having too much tag icons will make it hard to identify a specific one; it also does not support separating the tags into multiple rows.

#### Example usage & customization

```lua
theme.widget.tasklist.winmenu = {
    -- ...
    enable_tagline       = true,
    tagline_mod_key      = "Mod1", -- used for the 'move to and view tag' left-click action
}

theme.widget.tasklist.winmenu.icon = {
    -- ...
    tag                  = theme.path .. "/common/tagsymbol.svg",
}

theme.float.clientmenu = {
    -- ...
    icon                 = theme.widget.tasklist.winmenu.icon,
    enable_tagline       = true,
    tagline_mod_key      = "Mod1",
}
```


### Part II: screen switch option

Adds a 'move to next screen' button to the window menus. I use this a lot to move windows quickly between monitors wherever I need them. Not much to say about this one, it moves the client to the next screen in awesome's screen enumeration and cycles back to the first after the last. Even if this feature is enabled, the button/entry only appears if more than one screen is currently active.


#### Example usage & customization

```lua
theme.widget.tasklist.winmenu = {
    -- ...
    enable_screen_switch = true,
}

theme.widget.tasklist.winmenu.icon = {
    -- ...
    switch_screen        = theme.path .. "/clientmenu/switch.svg",
}

theme.float.clientmenu = {
    -- ...
    icon                 = theme.widget.tasklist.winmenu.icon,
    enable_screen_switch = true,
}
```

### Preview

| | Default theme, 8 tags | Styled example, 5 tags |
|---|---|---|
| `clientmenu` | ![vtag-sswitch-clientmenu-default](https://user-images.githubusercontent.com/1408105/96377949-3d34e300-1189-11eb-99ba-e3f0efa79412.jpg) | ![vtag-sswitch-clientmenu-styled](https://user-images.githubusercontent.com/1408105/96385593-301df100-1195-11eb-895b-0be766389811.jpg) |
| `tasklist.winmenu` | ![vtag-sswitch-winmenu-default](https://user-images.githubusercontent.com/1408105/96377952-41f99700-1189-11eb-8e1d-059b7afa3240.jpg) | ![vtag-sswitch-winmenu-styled](https://user-images.githubusercontent.com/1408105/96377964-4aea6880-1189-11eb-9e85-81a56b0869ec.jpg) |