### PR TITLE
Make logout screen execute callbacks only once

### DIFF
--- a/service/logout.lua
+++ b/service/logout.lua
@@ -342,6 +342,7 @@ function logout:init()
 			if countdown.delay <= 1 then
 				--logout:hide() -- do we need hide?
 				countdown.callback()
+				countdown:stop()
 			else
 				countdown.delay = countdown.delay - 1
 				countdown:label(countdown.delay)


### PR DESCRIPTION
Thanks for adopting and polishing the widget! I really like the solution about the countdown being displayed in the widget itself.

While I was testing the changes, I replaced the actual actions with dummy notifications. I happened to notice that if any action with `close_apps = true` is called, the timer will execute its callback again and again after the `client_kill_timeout`. For most shutdown actions that should be negligible as those will close down the awesome process almost instantly.

However, since the user is able to customize the actions, there might be commands that will not play well with being called multiple times and the user will expect the callback to be called exactly once after the `client_kill_timeout`. Thus, I added a small fix that stops the timer for such cases.