### PR TITLE
pulse: update default sink during autoupdate

### DIFF
--- a/widget/pulse.lua
+++ b/widget/pulse.lua
@@ -184,7 +184,7 @@ function pulse.new(args, style)
 	--------------------------------------------------------------------------------
 	if autoupdate then
 		local t = gears.timer({ timeout = timeout })
-		t:connect_signal("timeout", function() widg:update_volume() end)
+		t:connect_signal("timeout", function() widg:update_volume({ sink_update = true }) end)
 		t:start()
 	end
 


### PR DESCRIPTION
The default sink might change during several scenarios, for example:

- the default sound card is switched, e.g. from integrated audio to external USB or bluetooth adapter
- the pulseaudio card profile is changed, e.g. from "analog stereo duplex" to "digital stereo (HDMI) output", as required by some Intel HDA cards to switch between analog and HDMI audio

Thus, I think it is best to update the default sink during each autoupdate. The `sink_update` method argument was already implemented but I haven't seen it being used anywhere so I simply added it to the autoupdate callback.