### PR TITLE
navigator: make overlay window type configurable

### DIFF
--- a/service/navigator.lua
+++ b/service/navigator.lua
@@ -43,7 +43,8 @@ local function default_style()
 		color        = { border = "#575757", wibox = "#00000000", bg1 = "#57575740", bg2 = "#57575720",
 		                 fbg1 = "#b1222b40", fbg2 = "#b1222b20", mark = "#575757", text = "#202020",
 		                 hbg1 = "#32882d40", hbg2 = "#32882d20" },
-		shape        = nil
+		shape        = nil,
+		window_type  = nil,
 	}
 	return redutil.table.merge(style, redutil.table.check(beautiful, "service.navigator") or {})
 end
@@ -168,7 +169,8 @@ function navigator.make_decor(c)
 		bg           = style.color.wibox,
 		border_width = style.border_width,
 		border_color = style.color.border,
-		shape        = style.shape
+		shape        = style.shape,
+		type         = style.window_type,
 	})
 
 	object.client = c


### PR DESCRIPTION
This allows to change the [window type](https://awesomewm.org/doc/api/classes/client.html#client.type) of the `navigator` overlays by specifying it in the `theme.lua`:

```lua
theme.service.navigator = {
	...
	window_type  = "utility",
}
```
#### Impact

There should be no impact to existing configs which don't set this value because it defaults to `nil`, which matches the behavior before this patch.

#### Reasoning

I use both the the shadows and rounded corner functionalities of `picom`.

Without giving the `navigator` overlays dedicated window types it is impossible to specifically address them in the `picom` configuration in rules to exclude them from shadows while keeping their corners rounded to match the windows. Since they are semi-transparent in my config, the shadow visible through the transparency will lead to ugly visual artifacts because of the way shadow rendering and corner rounding intersect in `picom`.

Allowing them to have a dedicated window type, allows for picom rules like these:

```
corner-radius = 4;
shadow = true;
shadow-exclude = [
    ...
    "class_g ?= 'awesome' && window_type = 'utility'",
    ...
];
```

... which will round their corners but not apply shadows to them.