### PR TITLE
calendar: fix month label not updated correctly

### DIFF
--- a/float/calendar.lua
+++ b/float/calendar.lua
@@ -227,7 +227,7 @@ function calendar:init()
 		local month = os.date("%B", os.time{
 			year = self.date.year,
 			month = self.date.month,
-			day = self.date.day}
+			day = 1}
 		)
 		local year = string.format("%s", self.date.year)
 		self.month_label:set_markup('<span color="' .. style.color.text .. '">' .. month .. '</span>')


### PR DESCRIPTION
When the current day is at the end of the month (e.g. January 31st) and the calendar view is switched to a month with less days, the `os.date()` call for retrieving the month's name is passed an invalid date (e.g. November 31st), which leads to the label update to fail and the month name will stay at its previous value while the calendar view is still updated. As the month label doesn't depend on the day (not even the year), we can simply set it to `1`.

Note: There is a second place where this date combination is passed - the `self.calendar:set_date()` call in `calendar:show_date()`. However, this function does not seem to be bothered by this. Since we use the `day` value there only for highlighting within the current month, we do not depend on it being correct in any other month.  
Hence, I refrained from making any changes to that occurence.