### PR TITLE
player: restrict to configured player name

### DIFF
--- a/float/player.lua
+++ b/float/player.lua
@@ -117,6 +117,7 @@ function player:init(args)
 	self.info = { artist = "Unknown", album = "Unknown" }
 	self.style = style
 	self.last = { status = "Stopped", length = 5 * 60 * 1000000, volume = nil }
+	self.player = _player
 
 	-- dbus vars
 	self.command = {
@@ -513,7 +514,8 @@ function player:listen()
 	dbus.request_name("session", "org.freedesktop.DBus.Properties")
 	dbus.add_match(
 		"session",
-		"path=/org/mpris/MediaPlayer2, interface='org.freedesktop.DBus.Properties', member='PropertiesChanged'"
+		"sender='org.mpris.MediaPlayer2." .. self.player .. "', interface='org.freedesktop.DBus.Properties', "
+		.. "member='PropertiesChanged'"
 	)
 	dbus.connect_signal("org.freedesktop.DBus.Properties",
 		function (_, _, data)


### PR DESCRIPTION
This fixes a bug where opening a different media player than the one defined via `args.name` which also sends `org.mpris.MediaPlayer2` D-Bus signals from interfering with the information on the player widget.

Steps to reproduce:
1. open the player configured via `args.name` and start playback
2. open a different player (e.g. Audacious, VLC) and start playback
3. observe metadata in the player widget partially being replaced by the secondary player started in step 2

Functionality tested with Audacious and Clementine.